### PR TITLE
feat: add Redis queue and feed fetcher CronJob

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,10 @@ RSS feed aggregator with AI summarization on GKE. See README.md for project over
 | Choice | Value | Why |
 |--------|-------|-----|
 | GKE mode | Standard (not Autopilot) | Learning node management, scheduling |
-| Cluster | Zonal (asia-northeast1-a) | Free tier covers management fee |
+| Cluster | Zonal (us-central1-f) | Free tier covers management fee |
 | Nodes | e2-medium (2 vCPU, 4GB), 2 nodes (autoscaler 1-3) | Balance cost vs capacity |
-| Registry | Artifact Registry (asia-northeast1) | Regional = cheaper egress |
+| Registry | Artifact Registry (us-central1) | Regional = cheaper egress |
+| TF state bucket | GCS (asia-northeast1) | Created before region change, left as-is |
 | CI | Cloud Build | 120 free build-min/day |
 | IaC | Terraform with modules, GCS remote state | Learning goal |
 | K8s config | kustomize (base + overlays) | Environment management |
@@ -28,9 +29,9 @@ RSS feed aggregator with AI summarization on GKE. See README.md for project over
 - Format with `terraform fmt` before commit.
 
 ### Kubernetes
-- `kubectl diff` before `kubectl apply` for manual deploys.
+- NEVER run `kubectl` commands — the user runs all K8s commands themselves (learning project).
+- Provide the commands to run, but don't execute them.
 - NEVER `kubectl edit` — always change manifests and re-apply.
-- NEVER `kubectl delete namespace` on production.
 - Label everything: `app.kubernetes.io/name`, `app.kubernetes.io/component`, `app.kubernetes.io/part-of: feedforge`.
 
 ### Docker

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -11,6 +11,10 @@ class Settings(BaseSettings):
     db_password: str = "feedforge"
     debug: bool = False
 
+    redis_host: str = "localhost"
+    redis_port: int = 6379
+    redis_db: int = 0
+
     model_config = {"env_prefix": "FEEDFORGE_"}
 
     @property

--- a/backend/app/fetcher.py
+++ b/backend/app/fetcher.py
@@ -1,0 +1,166 @@
+"""Feed fetcher — parses RSS/Atom feeds, inserts new articles, queues for summarization."""
+
+import logging
+import time
+from datetime import UTC, datetime, timedelta
+
+import feedparser
+import redis
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from app.config import settings
+from app.database import SessionLocal
+from app.models.article import Article
+from app.models.feed import Feed
+
+logger = logging.getLogger(__name__)
+
+QUEUE_KEY = "feedforge:articles:pending"
+
+
+def get_redis() -> redis.Redis:
+    return redis.Redis(
+        host=settings.redis_host,
+        port=settings.redis_port,
+        db=settings.redis_db,
+        decode_responses=True,
+    )
+
+
+def get_due_feeds(db) -> list[Feed]:
+    """Return active feeds that are due for a refresh."""
+    now = datetime.now(UTC)
+    stmt = (
+        select(Feed)
+        .where(Feed.is_active.is_(True))
+        .where(
+            (Feed.last_fetched_at.is_(None))
+            | (Feed.last_fetched_at + timedelta(minutes=1) * Feed.fetch_interval_minutes < now)
+        )
+    )
+    return list(db.scalars(stmt).all())
+
+
+def _parse_published(entry) -> datetime | None:
+    parsed = getattr(entry, "published_parsed", None)
+    if parsed is None:
+        return None
+    try:
+        return datetime(*parsed[:6], tzinfo=UTC)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_content(entry) -> str | None:
+    """Get the best available content from a feed entry."""
+    # feedparser puts full content in entry.content[0].value when available
+    content_list = getattr(entry, "content", None)
+    if content_list:
+        return content_list[0].get("value")
+    return getattr(entry, "summary", None)
+
+
+def _update_feed_metadata(feed: Feed, parsed) -> None:
+    """Populate feed title/site_url/feed_type from parsed data on first fetch."""
+    feed_info = parsed.get("feed", {})
+    if not feed.title and feed_info.get("title"):
+        feed.title = feed_info["title"]
+    if not feed.site_url and feed_info.get("link"):
+        feed.site_url = feed_info["link"]
+    if not feed.feed_type and parsed.get("version"):
+        feed.feed_type = parsed["version"]
+
+
+def fetch_feed(feed: Feed, db, redis_client: redis.Redis | None) -> int:
+    """Fetch a single feed, insert new articles, push IDs to Redis queue.
+
+    Returns the number of new articles inserted.
+    """
+    parsed = feedparser.parse(feed.url)
+
+    if parsed.bozo and not parsed.entries:
+        logger.warning("Feed %s failed to parse: %s", feed.url, parsed.bozo_exception)
+        return 0
+
+    _update_feed_metadata(feed, parsed)
+
+    new_count = 0
+    now = datetime.now(UTC)
+
+    for entry in parsed.entries:
+        link = getattr(entry, "link", None)
+        title = getattr(entry, "title", None)
+        if not link or not title:
+            continue
+
+        article = Article(
+            feed_id=feed.id,
+            url=link[:2048],
+            title=title[:1000],
+            author=getattr(entry, "author", None),
+            content=_extract_content(entry),
+            published_at=_parse_published(entry),
+            fetched_at=now,
+        )
+
+        nested = db.begin_nested()
+        try:
+            db.add(article)
+            db.flush()
+            new_count += 1
+
+            if redis_client is not None:
+                try:
+                    redis_client.lpush(QUEUE_KEY, str(article.id))
+                except redis.RedisError:
+                    logger.warning("Failed to push article %s to Redis queue", article.id)
+        except IntegrityError:
+            nested.rollback()
+
+    feed.last_fetched_at = now
+    db.commit()
+    return new_count
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    logger.info("Feed fetcher starting")
+    start = time.monotonic()
+
+    db = SessionLocal()
+    try:
+        redis_client: redis.Redis | None = None
+        try:
+            redis_client = get_redis()
+            redis_client.ping()
+            logger.info("Connected to Redis at %s:%s", settings.redis_host, settings.redis_port)
+        except redis.RedisError:
+            logger.warning("Redis unavailable — articles will be inserted but not queued")
+            redis_client = None
+
+        feeds = get_due_feeds(db)
+        logger.info("Found %d feeds due for refresh", len(feeds))
+
+        total_new = 0
+        for feed in feeds:
+            try:
+                count = fetch_feed(feed, db, redis_client)
+                total_new += count
+                logger.info("Feed %s: %d new articles", feed.url, count)
+            except Exception:
+                logger.exception("Error fetching feed %s", feed.url)
+                db.rollback()
+
+        elapsed = time.monotonic() - start
+        logger.info("Fetcher complete: %d feeds processed, %d new articles (%.1fs)", len(feeds), total_new, elapsed)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,4 +10,6 @@ dependencies = [
     "psycopg[binary]>=3.2,<4",
     "alembic>=1.14,<2",
     "pydantic-settings>=2.7,<3",
+    "feedparser>=6.0,<7",
+    "redis>=5.0,<6",
 ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -91,8 +91,10 @@ source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
     { name = "fastapi" },
+    { name = "feedparser" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings" },
+    { name = "redis" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -101,10 +103,24 @@ dependencies = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.14,<2" },
     { name = "fastapi", specifier = ">=0.115,<1" },
+    { name = "feedparser", specifier = ">=6.0,<7" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2,<4" },
     { name = "pydantic-settings", specifier = ">=2.7,<3" },
+    { name = "redis", specifier = ">=5.0,<6" },
     { name = "sqlalchemy", specifier = ">=2.0,<3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34,<1" },
+]
+
+[[package]]
+name = "feedparser"
+version = "6.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sgmllib3k" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/79/db7edb5e77d6dfbc54d7d9df72828be4318275b2e580549ff45a962f6461/feedparser-6.0.12.tar.gz", hash = "sha256:64f76ce90ae3e8ef5d1ede0f8d3b50ce26bcce71dd8ae5e82b1cd2d4a5f94228", size = 286579, upload-time = "2025-09-10T13:33:59.486Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/eb/c96d64137e29ae17d83ad2552470bafe3a7a915e85434d9942077d7fd011/feedparser-6.0.12-py3-none-any.whl", hash = "sha256:6bbff10f5a52662c00a2e3f86a38928c37c48f77b3c511aedcd51de933549324", size = 81480, upload-time = "2025-09-10T13:33:58.022Z" },
 ]
 
 [[package]]
@@ -427,6 +443,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -480,6 +505,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
+
+[[package]]
+name = "redis"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/26/5c5fa0e83c3621db835cfc1f1d789b37e7fa99ed54423b5f519beb931aa7/redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97", size = 272833, upload-time = "2025-07-25T08:06:26.317Z" },
+]
+
+[[package]]
+name = "sgmllib3k"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
 
 [[package]]
 name = "sqlalchemy"

--- a/k8s/base/backend/configmap.yaml
+++ b/k8s/base/backend/configmap.yaml
@@ -11,4 +11,6 @@ data:
   FEEDFORGE_DB_HOST: "postgres.feedforge.svc.cluster.local"
   FEEDFORGE_DB_PORT: "5432"
   FEEDFORGE_DB_NAME: "feedforge"
+  FEEDFORGE_REDIS_HOST: "redis.feedforge.svc.cluster.local"
+  FEEDFORGE_REDIS_PORT: "6379"
   FEEDFORGE_DEBUG: "false"

--- a/k8s/base/backend/deployment.yaml
+++ b/k8s/base/backend/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       initContainers:
         - name: run-migrations
-          image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:0.1.2
+          image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:0.2.0
           command: ["alembic", "upgrade", "head"]
           envFrom:
             - configMapRef:
@@ -46,7 +46,7 @@ spec:
               memory: 128Mi
       containers:
         - name: backend
-          image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:0.1.2
+          image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:0.2.0
           ports:
             - containerPort: 8000
               name: http

--- a/k8s/base/fetcher/cronjob.yaml
+++ b/k8s/base/fetcher/cronjob.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: feed-fetcher
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: feed-fetcher
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/part-of: feedforge
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 300
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: feed-fetcher
+            app.kubernetes.io/component: worker
+            app.kubernetes.io/part-of: feedforge
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: fetcher
+              image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:0.2.0
+              command: ["python", "-m", "app.fetcher"]
+              envFrom:
+                - configMapRef:
+                    name: backend-config
+              env:
+                - name: FEEDFORGE_DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-credentials
+                      key: POSTGRES_USER
+                - name: FEEDFORGE_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-credentials
+                      key: POSTGRES_PASSWORD
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -10,6 +10,9 @@ resources:
   - namespace.yaml
   - postgres/service.yaml
   - postgres/statefulset.yaml
+  - redis/deployment.yaml
+  - redis/service.yaml
   - backend/configmap.yaml
   - backend/service.yaml
   - backend/deployment.yaml
+  - fetcher/cronjob.yaml

--- a/k8s/base/redis/deployment.yaml
+++ b/k8s/base/redis/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: queue
+    app.kubernetes.io/part-of: feedforge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/component: queue
+        app.kubernetes.io/part-of: feedforge
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.4-alpine
+          ports:
+            - containerPort: 6379
+              name: redis
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3

--- a/k8s/base/redis/service.yaml
+++ b/k8s/base/redis/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: queue
+    app.kubernetes.io/part-of: feedforge
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      name: redis

--- a/terraform/environments/dev/terraform.tfvars.example
+++ b/terraform/environments/dev/terraform.tfvars.example
@@ -1,3 +1,3 @@
 project_id = "your-project-id-here"
-region     = "asia-northeast1"
-zone       = "asia-northeast1-a"
+region     = "us-central1"
+zone       = "us-central1-f"

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -5,10 +5,10 @@ variable "project_id" {
 
 variable "region" {
   type    = string
-  default = "asia-northeast1"
+  default = "us-central1"
 }
 
 variable "zone" {
   type    = string
-  default = "asia-northeast1-a"
+  default = "us-central1-f"
 }

--- a/terraform/modules/artifact-registry/variables.tf
+++ b/terraform/modules/artifact-registry/variables.tf
@@ -5,7 +5,7 @@ variable "project_id" {
 
 variable "region" {
   type    = string
-  default = "asia-northeast1"
+  default = "us-central1"
 }
 
 variable "repository_id" {

--- a/terraform/modules/gke/variables.tf
+++ b/terraform/modules/gke/variables.tf
@@ -10,7 +10,7 @@ variable "region" {
 
 variable "zone" {
   type    = string
-  default = "asia-northeast1-a"
+  default = "us-central1-f"
 }
 
 variable "cluster_name" {


### PR DESCRIPTION
## Summary
- Add Redis Deployment + ClusterIP Service as the message queue between fetcher and summarizer
- Add feed fetcher script (`app/fetcher.py`) that parses RSS/Atom feeds, inserts new articles, and queues article IDs in Redis
- Add CronJob (`feed-fetcher`) running every 15 minutes with `concurrencyPolicy: Forbid`
- Add `feedparser` and `redis` Python dependencies
- Bump backend image tag to `0.2.0`
- Update region from asia-northeast1 to us-central1 in Terraform configs and CLAUDE.md

## K8s Concepts Introduced
- **CronJob** — scheduled feed fetching every 15 minutes
- **Redis Deployment** — transient queue, no PVC (re-fetch on restart is harmless)

## Test plan
- [x] `kubectl kustomize k8s/base/` renders cleanly
- [x] Image built and pushed via `gcloud builds submit`
- [x] Manual CronJob trigger: `kubectl create job --from=cronjob/feed-fetcher` — fetched 20 articles from Ars Technica
- [x] Redis queue populated: `redis-cli llen feedforge:articles:pending` → 40

🤖 Generated with [Claude Code](https://claude.com/claude-code)