### PR TITLE
infra: add Cloud Build CI/CD, skaffold, and rolling updates

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,52 @@
+steps:
+  # Build backend image (used by backend, summarizer, fetcher)
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/feedforge/backend:$SHORT_SHA'
+      - './backend'
+
+  # Build frontend image
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/feedforge/frontend:$SHORT_SHA'
+      - './frontend'
+
+  # Push backend image
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/feedforge/backend:$SHORT_SHA'
+
+  # Push frontend image
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/feedforge/frontend:$SHORT_SHA'
+
+  # Deploy to GKE via kustomize
+  - name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        gcloud container clusters get-credentials feedforge-cluster \
+          --zone us-central1-f --project $PROJECT_ID
+
+        cd k8s/overlays/dev
+        kustomize edit set image \
+          us-central1-docker.pkg.dev/$PROJECT_ID/feedforge/backend=us-central1-docker.pkg.dev/$PROJECT_ID/feedforge/backend:$SHORT_SHA \
+          us-central1-docker.pkg.dev/$PROJECT_ID/feedforge/frontend=us-central1-docker.pkg.dev/$PROJECT_ID/feedforge/frontend:$SHORT_SHA
+
+        kubectl apply -k .
+        kubectl -n feedforge rollout status deployment/backend --timeout=120s
+        kubectl -n feedforge rollout status deployment/frontend --timeout=120s
+        kubectl -n feedforge rollout status deployment/summarizer --timeout=120s
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+
+timeout: '600s'

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -47,7 +47,7 @@
 | PodDisruptionBudget | P4 | ☐ |
 | Resource requests/limits | P1 | ☑ |
 | Liveness/readiness probes | P1 | ☑ |
-| Rolling update strategy | P3 | ☐ |
+| Rolling update strategy | P3 | ☑ |
 | kustomize overlays | P3 | ☑ |
 | BackendConfig (Cloud Armor) | P3 | ☑ |
 
@@ -107,10 +107,10 @@
 - [x] Configure Ingress (path-based: / → frontend, /api → backend)
 - [x] Set up kustomize overlays for dev
 - [x] Add Cloud Armor IP restriction (Terraform module + BackendConfig)
-- [ ] Write cloudbuild.yaml (build all images → push → deploy)
-- [ ] Set up Cloud Build trigger on GitHub push to main
-- [ ] Write skaffold.yaml for local dev loop
-- [ ] Configure rolling update strategy on Deployments
+- [x] Write cloudbuild.yaml (build all images → push → deploy)
+- [x] Set up Cloud Build trigger on GitHub push to main (Terraform module)
+- [x] Write skaffold.yaml for local dev loop
+- [x] Configure rolling update strategy on Deployments
 - [ ] Verify full CI/CD: push code → auto-deploy → verify in browser
 
 ## Phase 4: Advanced K8s + Notifications

--- a/k8s/base/backend/deployment.yaml
+++ b/k8s/base/backend/deployment.yaml
@@ -9,6 +9,11 @@ metadata:
     app.kubernetes.io/part-of: feedforge
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: backend

--- a/k8s/base/frontend/deployment.yaml
+++ b/k8s/base/frontend/deployment.yaml
@@ -9,6 +9,11 @@ metadata:
     app.kubernetes.io/part-of: feedforge
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: frontend

--- a/k8s/base/summarizer/deployment.yaml
+++ b/k8s/base/summarizer/deployment.yaml
@@ -9,6 +9,11 @@ metadata:
     app.kubernetes.io/part-of: feedforge
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: summarizer

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,32 @@
+apiVersion: skaffold/v4beta11
+kind: Config
+metadata:
+  name: feedforge
+
+build:
+  artifacts:
+    - image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend
+      context: backend
+      docker:
+        dockerfile: Dockerfile
+    - image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/frontend
+      context: frontend
+      docker:
+        dockerfile: Dockerfile
+
+deploy:
+  kustomize:
+    paths:
+      - k8s/overlays/dev
+
+portForward:
+  - resourceType: service
+    resourceName: backend
+    namespace: feedforge
+    port: 8000
+    localPort: 8000
+  - resourceType: service
+    resourceName: frontend
+    namespace: feedforge
+    port: 80
+    localPort: 8080

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -36,7 +36,15 @@ module "artifact_registry" {
 }
 
 module "cloud_armor" {
-  source     = "../../modules/cloud-armor"
-  project_id = var.project_id
+  source      = "../../modules/cloud-armor"
+  project_id  = var.project_id
   allowed_ips = var.allowed_ips
+}
+
+module "cloud_build" {
+  source          = "../../modules/cloud-build"
+  project_id      = var.project_id
+  region          = var.region
+  connection_name = "github"
+  repository_name = "huchka-feedforge"
 }

--- a/terraform/modules/cloud-build/main.tf
+++ b/terraform/modules/cloud-build/main.tf
@@ -1,0 +1,20 @@
+data "google_project" "current" {
+  project_id = var.project_id
+}
+
+resource "google_cloudbuild_trigger" "deploy" {
+  name        = var.trigger_name
+  project     = var.project_id
+  location    = var.region
+
+  repository_event_config {
+    repository = "projects/${var.project_id}/locations/${var.region}/connections/${var.connection_name}/repositories/${var.repository_name}"
+
+    push {
+      branch = "^main$"
+    }
+  }
+
+  service_account = "projects/${var.project_id}/serviceAccounts/${data.google_project.current.number}@cloudbuild.gserviceaccount.com"
+  filename        = "cloudbuild.yaml"
+}

--- a/terraform/modules/cloud-build/outputs.tf
+++ b/terraform/modules/cloud-build/outputs.tf
@@ -1,0 +1,3 @@
+output "trigger_id" {
+  value = google_cloudbuild_trigger.deploy.trigger_id
+}

--- a/terraform/modules/cloud-build/variables.tf
+++ b/terraform/modules/cloud-build/variables.tf
@@ -1,0 +1,24 @@
+variable "project_id" {
+  type        = string
+  description = "GCP project ID"
+}
+
+variable "region" {
+  type    = string
+  default = "us-central1"
+}
+
+variable "trigger_name" {
+  type    = string
+  default = "feedforge-deploy"
+}
+
+variable "connection_name" {
+  type        = string
+  description = "Cloud Build v2 connection name"
+}
+
+variable "repository_name" {
+  type        = string
+  description = "Cloud Build v2 linked repository name"
+}

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -22,3 +22,25 @@ resource "google_project_iam_member" "gke_node_roles" {
   role    = each.value
   member  = "serviceAccount:${google_service_account.gke_nodes.email}"
 }
+
+# Cloud Build default SA — needs GKE deploy + AR push permissions
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+locals {
+  cloud_build_sa = "${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+
+  cloud_build_roles = [
+    "roles/container.developer",
+    "roles/artifactregistry.writer",
+  ]
+}
+
+resource "google_project_iam_member" "cloud_build_roles" {
+  for_each = toset(local.cloud_build_roles)
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${local.cloud_build_sa}"
+}


### PR DESCRIPTION
## Summary
- Add `cloudbuild.yaml` pipeline: build backend+frontend images, push to Artifact Registry, deploy to GKE via kustomize
- Add Cloud Build trigger Terraform module (v2 connection) with IAM bindings for the Cloud Build SA
- Add `skaffold.yaml` for local dev loop with kustomize deployer and port-forwarding
- Add rolling update strategy (`maxUnavailable=0, maxSurge=1`) to backend, frontend, and summarizer deployments

Completes Phase 3 (minus final CI/CD verification which this merge will trigger).

## Test plan
- [ ] Merge to main triggers Cloud Build
- [ ] Build completes: both images built and pushed with `$SHORT_SHA` tag
- [ ] Deploy step: kustomize patches image tags and applies to GKE
- [ ] Rollout completes for backend, frontend, summarizer
- [ ] App accessible via ingress

🤖 Generated with [Claude Code](https://claude.com/claude-code)