### PR TITLE
fix: use user-managed SA for Cloud Build trigger

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -42,9 +42,12 @@ module "cloud_armor" {
 }
 
 module "cloud_build" {
-  source          = "../../modules/cloud-build"
-  project_id      = var.project_id
-  region          = var.region
-  connection_name = "github"
-  repository_name = "huchka-feedforge"
+  source                = "../../modules/cloud-build"
+  project_id            = var.project_id
+  region                = var.region
+  connection_name       = "github"
+  repository_name       = "huchka-feedforge"
+  service_account_email = module.iam.cloud_build_sa_email
+
+  depends_on = [module.iam]
 }

--- a/terraform/modules/cloud-build/main.tf
+++ b/terraform/modules/cloud-build/main.tf
@@ -1,7 +1,3 @@
-data "google_project" "current" {
-  project_id = var.project_id
-}
-
 resource "google_cloudbuild_trigger" "deploy" {
   name        = var.trigger_name
   project     = var.project_id
@@ -15,6 +11,6 @@ resource "google_cloudbuild_trigger" "deploy" {
     }
   }
 
-  service_account = "projects/${var.project_id}/serviceAccounts/${data.google_project.current.number}@cloudbuild.gserviceaccount.com"
+  service_account = "projects/${var.project_id}/serviceAccounts/${var.service_account_email}"
   filename        = "cloudbuild.yaml"
 }

--- a/terraform/modules/cloud-build/variables.tf
+++ b/terraform/modules/cloud-build/variables.tf
@@ -22,3 +22,8 @@ variable "repository_name" {
   type        = string
   description = "Cloud Build v2 linked repository name"
 }
+
+variable "service_account_email" {
+  type        = string
+  description = "User-managed service account email for Cloud Build"
+}

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -23,17 +23,18 @@ resource "google_project_iam_member" "gke_node_roles" {
   member  = "serviceAccount:${google_service_account.gke_nodes.email}"
 }
 
-# Cloud Build default SA — needs GKE deploy + AR push permissions
-data "google_project" "project" {
-  project_id = var.project_id
+# Cloud Build — user-managed SA (required for v2 triggers)
+resource "google_service_account" "cloud_build" {
+  account_id   = "feedforge-cloud-build"
+  display_name = "FeedForge Cloud Build Service Account"
+  project      = var.project_id
 }
 
 locals {
-  cloud_build_sa = "${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
-
   cloud_build_roles = [
     "roles/container.developer",
     "roles/artifactregistry.writer",
+    "roles/logging.logWriter",
   ]
 }
 
@@ -42,5 +43,5 @@ resource "google_project_iam_member" "cloud_build_roles" {
 
   project = var.project_id
   role    = each.value
-  member  = "serviceAccount:${local.cloud_build_sa}"
+  member  = "serviceAccount:${google_service_account.cloud_build.email}"
 }

--- a/terraform/modules/iam/outputs.tf
+++ b/terraform/modules/iam/outputs.tf
@@ -1,3 +1,7 @@
 output "gke_node_sa_email" {
   value = google_service_account.gke_nodes.email
 }
+
+output "cloud_build_sa_email" {
+  value = google_service_account.cloud_build.email
+}


### PR DESCRIPTION
## Summary
- v2 Cloud Build triggers reject the default SA — create a dedicated `feedforge-cloud-build` user-managed SA
- Grant it `container.developer`, `artifactregistry.writer`, and `logging.logWriter` roles
- Wire the SA through the cloud-build Terraform module

🤖 Generated with [Claude Code](https://claude.com/claude-code)