### PR TITLE
feat: complete Phase 5 — RBAC, Workload Identity, DB backup Job

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -35,13 +35,13 @@
 | PersistentVolumeClaim | P1 | ☑ |
 | Ingress | P3 | ☑ |
 | CronJob | P2 | ☑ |
-| Job | P4 | ☐ |
+| Job | P5 | ☑ |
 | HPA | P4 | ☑ |
 | Init container | P1 | ☑ |
 | NetworkPolicy | P5 | ☑ |
 | SecurityContext | P5 | ☑ |
-| RBAC / ServiceAccount | P5 | ☐ |
-| Workload Identity | P5 | ☐ |
+| RBAC / ServiceAccount | P5 | ☑ |
+| Workload Identity | P5 | ☑ |
 | Sidecar container | P6 | ☐ |
 | ResourceQuota / LimitRange | P6 | ☐ |
 | PodDisruptionBudget | P6 | ☐ |
@@ -128,8 +128,8 @@
 - [x] Add NetworkPolicy (DB only accessible from backend/workers, Redis only from workers)
 - [x] Enable Calico + metrics-server via Terraform
 - [x] Add SecurityContext (non-root, read-only filesystem where possible)
-- [ ] Add RBAC / ServiceAccount (dedicated SAs per workload)
-- [ ] Configure Workload Identity for GCS access (optional: backup DB to GCS)
+- [x] Add RBAC / ServiceAccount (dedicated SAs per workload, automountServiceAccountToken: false)
+- [x] Configure Workload Identity for GCS access (db-backup Job → GCS via WI)
 
 ## Phase 6: Reliability & Observability
 **Goal**: Resource governance, availability guarantees, monitoring.

--- a/k8s/base/backend/deployment.yaml
+++ b/k8s/base/backend/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         app.kubernetes.io/component: api
         app.kubernetes.io/part-of: feedforge
     spec:
+      serviceAccountName: backend
       securityContext:
         runAsNonRoot: true
         runAsUser: 999

--- a/k8s/base/backend/serviceaccount.yaml
+++ b/k8s/base/backend/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backend
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: feedforge
+automountServiceAccountToken: false

--- a/k8s/base/backup/configmap.yaml
+++ b/k8s/base/backup/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backup-config
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: db-backup
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/part-of: feedforge
+data:
+  BACKUP_BUCKET: feedforge-db-backup-project-76da2d1f-231c-4c94-ae9
+  PGHOST: postgres
+  PGDATABASE: feedforge

--- a/k8s/base/backup/job.yaml
+++ b/k8s/base/backup/job.yaml
@@ -1,0 +1,75 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-backup
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: db-backup
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/part-of: feedforge
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: db-backup
+        app.kubernetes.io/component: backup
+        app.kubernetes.io/part-of: feedforge
+    spec:
+      serviceAccountName: db-backup
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 70
+        runAsGroup: 70
+      containers:
+        - name: pg-dump
+          image: postgres:16.6-alpine
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+              OBJECT="feedforge-${TIMESTAMP}.sql.gz"
+              pg_dump -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" --no-password | gzip > /tmp/backup.sql.gz
+              TOKEN=$(wget -q -O- --header="Metadata-Flavor: Google" \
+                "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token" | \
+                sed 's/.*"access_token":"\([^"]*\)".*/\1/')
+              wget -q -O /dev/null --post-file=/tmp/backup.sql.gz \
+                --header="Authorization: Bearer ${TOKEN}" \
+                --header="Content-Type: application/gzip" \
+                "https://storage.googleapis.com/upload/storage/v1/b/${BACKUP_BUCKET}/o?uploadType=media&name=${OBJECT}"
+              echo "Backup uploaded: gs://${BACKUP_BUCKET}/${OBJECT}"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          envFrom:
+            - configMapRef:
+                name: backup-config
+          env:
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: POSTGRES_USER
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: POSTGRES_PASSWORD
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/k8s/base/backup/serviceaccount.yaml
+++ b/k8s/base/backup/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: db-backup
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: db-backup
+    app.kubernetes.io/component: backup
+    app.kubernetes.io/part-of: feedforge
+automountServiceAccountToken: false

--- a/k8s/base/digest/cronjob.yaml
+++ b/k8s/base/digest/cronjob.yaml
@@ -23,6 +23,7 @@ spec:
             app.kubernetes.io/component: worker
             app.kubernetes.io/part-of: feedforge
         spec:
+          serviceAccountName: daily-digest
           restartPolicy: Never
           securityContext:
             runAsNonRoot: true

--- a/k8s/base/digest/serviceaccount.yaml
+++ b/k8s/base/digest/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: daily-digest
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: daily-digest
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/part-of: feedforge
+automountServiceAccountToken: false

--- a/k8s/base/fetcher/cronjob.yaml
+++ b/k8s/base/fetcher/cronjob.yaml
@@ -23,6 +23,7 @@ spec:
             app.kubernetes.io/component: worker
             app.kubernetes.io/part-of: feedforge
         spec:
+          serviceAccountName: feed-fetcher
           restartPolicy: Never
           securityContext:
             runAsNonRoot: true

--- a/k8s/base/fetcher/serviceaccount.yaml
+++ b/k8s/base/fetcher/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: feed-fetcher
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: feed-fetcher
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/part-of: feedforge
+automountServiceAccountToken: false

--- a/k8s/base/frontend/deployment.yaml
+++ b/k8s/base/frontend/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         app.kubernetes.io/component: web
         app.kubernetes.io/part-of: feedforge
     spec:
+      serviceAccountName: frontend
       securityContext:
         runAsNonRoot: true
         runAsUser: 100

--- a/k8s/base/frontend/serviceaccount.yaml
+++ b/k8s/base/frontend/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: frontend
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/part-of: feedforge
+automountServiceAccountToken: false

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -8,21 +8,31 @@ kind: Kustomization
 
 resources:
   - namespace.yaml
+  - postgres/serviceaccount.yaml
   - postgres/service.yaml
   - postgres/statefulset.yaml
   - postgres/networkpolicy.yaml
+  - redis/serviceaccount.yaml
   - redis/deployment.yaml
   - redis/service.yaml
   - redis/networkpolicy.yaml
+  - backend/serviceaccount.yaml
   - backend/configmap.yaml
   - backend/service.yaml
   - backend/deployment.yaml
   - backend/hpa.yaml
+  - frontend/serviceaccount.yaml
   - frontend/service.yaml
   - frontend/deployment.yaml
   - ingress/ingress.yaml
   - ingress/backend-config.yaml
+  - fetcher/serviceaccount.yaml
   - fetcher/cronjob.yaml
+  - summarizer/serviceaccount.yaml
   - summarizer/deployment.yaml
   - summarizer/hpa.yaml
+  - digest/serviceaccount.yaml
   - digest/cronjob.yaml
+  - backup/serviceaccount.yaml
+  - backup/configmap.yaml
+  - backup/job.yaml

--- a/k8s/base/postgres/serviceaccount.yaml
+++ b/k8s/base/postgres/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: postgres
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: feedforge
+automountServiceAccountToken: false

--- a/k8s/base/postgres/statefulset.yaml
+++ b/k8s/base/postgres/statefulset.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/component: database
         app.kubernetes.io/part-of: feedforge
     spec:
+      serviceAccountName: postgres
       securityContext:
         runAsNonRoot: true
         runAsUser: 70

--- a/k8s/base/redis/deployment.yaml
+++ b/k8s/base/redis/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/component: queue
         app.kubernetes.io/part-of: feedforge
     spec:
+      serviceAccountName: redis
       securityContext:
         runAsNonRoot: true
         runAsUser: 999

--- a/k8s/base/redis/serviceaccount.yaml
+++ b/k8s/base/redis/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redis
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: cache
+    app.kubernetes.io/part-of: feedforge
+automountServiceAccountToken: false

--- a/k8s/base/summarizer/deployment.yaml
+++ b/k8s/base/summarizer/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         app.kubernetes.io/component: worker
         app.kubernetes.io/part-of: feedforge
     spec:
+      serviceAccountName: summarizer
       securityContext:
         runAsNonRoot: true
         runAsUser: 999

--- a/k8s/base/summarizer/serviceaccount.yaml
+++ b/k8s/base/summarizer/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: summarizer
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: summarizer
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/part-of: feedforge
+automountServiceAccountToken: false

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 
 patches:
   - path: patches/backend-config-patch.yaml
+  - path: patches/backup-sa-patch.yaml

--- a/k8s/overlays/dev/patches/backup-sa-patch.yaml
+++ b/k8s/overlays/dev/patches/backup-sa-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: db-backup
+  namespace: feedforge
+  annotations:
+    iam.gke.io/gcp-service-account: feedforge-db-backup@project-76da2d1f-231c-4c94-ae9.iam.gserviceaccount.com

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -6,6 +6,7 @@ provider "google" {
 module "iam" {
   source     = "../../modules/iam"
   project_id = var.project_id
+  region     = var.region
 }
 
 module "network" {
@@ -39,6 +40,15 @@ module "cloud_armor" {
   source      = "../../modules/cloud-armor"
   project_id  = var.project_id
   allowed_ips = var.allowed_ips
+}
+
+# Workload Identity binding — must run after GKE (creates the WI pool)
+resource "google_service_account_iam_member" "db_backup_workload_identity" {
+  service_account_id = module.iam.db_backup_sa_name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[feedforge/db-backup]"
+
+  depends_on = [module.gke]
 }
 
 module "cloud_build" {

--- a/terraform/modules/cloud-build/main.tf
+++ b/terraform/modules/cloud-build/main.tf
@@ -1,7 +1,7 @@
 resource "google_cloudbuild_trigger" "deploy" {
-  name        = var.trigger_name
-  project     = var.project_id
-  location    = var.region
+  name     = var.trigger_name
+  project  = var.project_id
+  location = var.region
 
   repository_event_config {
     repository = "projects/${var.project_id}/locations/${var.region}/connections/${var.connection_name}/repositories/${var.repository_name}"

--- a/terraform/modules/gke/main.tf
+++ b/terraform/modules/gke/main.tf
@@ -27,6 +27,10 @@ resource "google_container_cluster" "primary" {
 
   datapath_provider = "ADVANCED_DATAPATH"
 
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
   addons_config {
     http_load_balancing {
       disabled = false
@@ -57,6 +61,10 @@ resource "google_container_node_pool" "primary" {
     disk_size_gb    = var.disk_size_gb
     disk_type       = var.disk_type
     service_account = var.node_service_account
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform",

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -45,3 +45,36 @@ resource "google_project_iam_member" "cloud_build_roles" {
   role    = each.value
   member  = "serviceAccount:${google_service_account.cloud_build.email}"
 }
+
+# --- DB Backup (Workload Identity) ---
+
+resource "google_service_account" "db_backup" {
+  account_id   = "feedforge-db-backup"
+  display_name = "FeedForge DB Backup Service Account"
+  project      = var.project_id
+}
+
+resource "google_storage_bucket" "db_backup" {
+  name     = "feedforge-db-backup-${var.project_id}"
+  project  = var.project_id
+  location = var.region
+
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+
+  lifecycle_rule {
+    condition {
+      age = 7
+    }
+    action {
+      type = "Delete"
+    }
+  }
+}
+
+resource "google_storage_bucket_iam_member" "db_backup_writer" {
+  bucket = google_storage_bucket.db_backup.name
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${google_service_account.db_backup.email}"
+}
+

--- a/terraform/modules/iam/outputs.tf
+++ b/terraform/modules/iam/outputs.tf
@@ -5,3 +5,15 @@ output "gke_node_sa_email" {
 output "cloud_build_sa_email" {
   value = google_service_account.cloud_build.email
 }
+
+output "db_backup_sa_email" {
+  value = google_service_account.db_backup.email
+}
+
+output "db_backup_sa_name" {
+  value = google_service_account.db_backup.name
+}
+
+output "db_backup_bucket_name" {
+  value = google_storage_bucket.db_backup.name
+}

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -7,3 +7,9 @@ variable "gke_sa_name" {
   type    = string
   default = "feedforge-gke-nodes"
 }
+
+variable "region" {
+  type    = string
+  default = "us-central1"
+}
+


### PR DESCRIPTION
## Summary
- Dedicated ServiceAccount per workload (8 total) with `automountServiceAccountToken: false` — pods no longer share the default SA or get auto-mounted API tokens
- Workload Identity enabled on GKE cluster + node pool, with GCP SA (`feedforge-db-backup`) bound to K8s SA (`db-backup`) for GCS access
- GCS bucket (`feedforge-db-backup-<project>`) with 7-day auto-delete lifecycle for pg_dump backups
- DB backup Job using `postgres:16.6-alpine` — dumps via `pg_dump`, uploads to GCS via JSON API with WI token from metadata server
- WI annotation moved to dev overlay patch for environment portability

Completes Phase 5 (Security Hardening) and ticks off three K8s learning concepts: RBAC/ServiceAccount, Workload Identity, Job.

## Test plan
- [x] `terraform apply` — Workload Identity enabled, GCP SA + bucket + IAM binding created
- [x] `kubectl get sa -n feedforge` — all 8 SAs exist
- [x] Pods running with dedicated SAs (verified via `kubectl get pods -o custom-columns`)
- [x] `kubectl create job db-backup-test --from=job/db-backup` — backup uploaded to GCS
- [x] `gsutil ls` — backup file visible in bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)