### PR TITLE
feat: Phase 6 reliability, observability, and infra hardening

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -42,9 +42,11 @@
 | SecurityContext | P5 | ☑ |
 | RBAC / ServiceAccount | P5 | ☑ |
 | Workload Identity | P5 | ☑ |
-| Sidecar container | P6 | ☐ |
-| ResourceQuota / LimitRange | P6 | ☐ |
-| PodDisruptionBudget | P6 | ☐ |
+| Sidecar container | P6 | ☑ |
+| ResourceQuota / LimitRange | P6 | ☑ |
+| PodDisruptionBudget | P6 | ☑ |
+| Maintenance window | P6 | ☑ |
+| Surge upgrade strategy | P6 | ☑ |
 | Resource requests/limits | P1 | ☑ |
 | Liveness/readiness probes | P1 | ☑ |
 | Rolling update strategy | P3 | ☑ |
@@ -135,9 +137,12 @@
 **Goal**: Resource governance, availability guarantees, monitoring.
 **Verification**: ResourceQuota enforced, PDB prevents full disruption during node drain, metrics visible.
 
-- [ ] Add ResourceQuota / LimitRange on namespace
-- [ ] Add PodDisruptionBudget on backend
-- [ ] Add sidecar container (e.g., metrics exporter)
+- [x] Add ResourceQuota / LimitRange on namespace
+- [x] Add PodDisruptionBudget on backend, frontend, summarizer
+- [x] Add sidecar container (log-exporter on backend)
+- [x] Add GKE maintenance window (daily 02:00–06:00 UTC via Terraform)
+- [x] Add surge upgrade strategy (max_surge=1, max_unavailable=0)
+- [x] Upgrade node machine type to e2-standard-2
 - [ ] Set up Prometheus + basic monitoring (stretch)
 
 ## Cost Budget
@@ -147,12 +152,12 @@
 | Resource | Monthly Estimate |
 |----------|-----------------|
 | GKE cluster management (zonal) | $0 (free tier) |
-| 2× e2-medium nodes (2 vCPU, 4GB) | ~$49 |
+| 2× e2-standard-2 nodes (2 vCPU, 8GB) | ~$97 |
 | Persistent disk 20GB (SSD) | ~$3.40 |
 | Artifact Registry storage | ~$1-2 |
 | Cloud Build | ~$0 (free tier) |
 | Network egress | ~$1-2 |
-| **Total** | **~$55/month** |
+| **Total** | **~$103/month** |
 
 **Budget rules**:
 - $300 credit / 88 days ≈ $3.40/day budget

--- a/k8s/base/backend/deployment.yaml
+++ b/k8s/base/backend/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         runAsGroup: 999
       initContainers:
         - name: run-migrations
-          image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:0.2.2
+          image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:phase-5-rbac-wi-2-g1369e4e
           command: ["alembic", "upgrade", "head"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -59,9 +59,33 @@ spec:
             limits:
               cpu: 200m
               memory: 128Mi
+        - name: log-exporter
+          image: busybox:1.37
+          restartPolicy: Always
+          command: ["sh", "-c"]
+          args:
+            - touch /var/log/app/access.log && tail -f /var/log/app/access.log
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+          volumeMounts:
+            - name: app-logs
+              mountPath: /var/log/app
       containers:
         - name: backend
-          image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:0.2.2
+          image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:phase-5-rbac-wi-2-g1369e4e
+          command: ["sh", "-c"]
+          args:
+            - uvicorn app.main:app --host 0.0.0.0 --port 8000 2>&1 | tee /var/log/app/access.log
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -91,6 +115,9 @@ spec:
             limits:
               cpu: 500m
               memory: 256Mi
+          volumeMounts:
+            - name: app-logs
+              mountPath: /var/log/app
           livenessProbe:
             httpGet:
               path: /api/health
@@ -105,3 +132,6 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 3
+      volumes:
+        - name: app-logs
+          emptyDir: {}

--- a/k8s/base/backend/pdb.yaml
+++ b/k8s/base/backend/pdb.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/part-of: feedforge
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: backend

--- a/k8s/base/backend/pdb.yaml
+++ b/k8s/base/backend/pdb.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: backend
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: feedforge
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: backend

--- a/k8s/base/digest/cronjob.yaml
+++ b/k8s/base/digest/cronjob.yaml
@@ -31,7 +31,7 @@ spec:
             runAsGroup: 999
           containers:
             - name: digest
-              image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:0.2.2
+              image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:phase-5-rbac-wi-2-g1369e4e
               command: ["python", "-m", "app.digest"]
               securityContext:
                 allowPrivilegeEscalation: false

--- a/k8s/base/fetcher/cronjob.yaml
+++ b/k8s/base/fetcher/cronjob.yaml
@@ -31,7 +31,7 @@ spec:
             runAsGroup: 999
           containers:
             - name: fetcher
-              image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:0.2.2
+              image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:phase-5-rbac-wi-2-g1369e4e
               command: ["python", "-m", "app.fetcher"]
               securityContext:
                 allowPrivilegeEscalation: false

--- a/k8s/base/frontend/deployment.yaml
+++ b/k8s/base/frontend/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         runAsGroup: 102
       containers:
         - name: frontend
-          image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/frontend:0.3.0
+          image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/frontend:phase-5-rbac-wi-2-g1369e4e
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/base/frontend/pdb.yaml
+++ b/k8s/base/frontend/pdb.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: frontend
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: web
+    app.kubernetes.io/part-of: feedforge
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend

--- a/k8s/base/frontend/pdb.yaml
+++ b/k8s/base/frontend/pdb.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: web
     app.kubernetes.io/part-of: feedforge
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: frontend

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -8,6 +8,8 @@ kind: Kustomization
 
 resources:
   - namespace.yaml
+  - namespace-quota.yaml
+  - namespace-limitrange.yaml
   - postgres/serviceaccount.yaml
   - postgres/service.yaml
   - postgres/statefulset.yaml
@@ -21,9 +23,11 @@ resources:
   - backend/service.yaml
   - backend/deployment.yaml
   - backend/hpa.yaml
+  - backend/pdb.yaml
   - frontend/serviceaccount.yaml
   - frontend/service.yaml
   - frontend/deployment.yaml
+  - frontend/pdb.yaml
   - ingress/ingress.yaml
   - ingress/backend-config.yaml
   - fetcher/serviceaccount.yaml
@@ -31,6 +35,7 @@ resources:
   - summarizer/serviceaccount.yaml
   - summarizer/deployment.yaml
   - summarizer/hpa.yaml
+  - summarizer/pdb.yaml
   - digest/serviceaccount.yaml
   - digest/cronjob.yaml
   - backup/serviceaccount.yaml

--- a/k8s/base/namespace-limitrange.yaml
+++ b/k8s/base/namespace-limitrange.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: feedforge-limits
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/part-of: feedforge
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: 200m
+        memory: 128Mi
+      defaultRequest:
+        cpu: 50m
+        memory: 64Mi
+      max:
+        cpu: 500m
+        memory: 512Mi

--- a/k8s/base/namespace-quota.yaml
+++ b/k8s/base/namespace-quota.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: feedforge-quota
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/part-of: feedforge
+spec:
+  hard:
+    requests.cpu: "1"
+    requests.memory: 1536Mi
+    limits.cpu: "3"
+    limits.memory: 2560Mi
+    pods: "15"

--- a/k8s/base/summarizer/deployment.yaml
+++ b/k8s/base/summarizer/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 45
       containers:
         - name: summarizer
-          image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:0.2.2
+          image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:phase-5-rbac-wi-2-g1369e4e
           command: ["python", "-m", "app.summarizer"]
           securityContext:
             allowPrivilegeEscalation: false

--- a/k8s/base/summarizer/hpa.yaml
+++ b/k8s/base/summarizer/hpa.yaml
@@ -13,7 +13,7 @@ spec:
     kind: Deployment
     name: summarizer
   minReplicas: 1
-  maxReplicas: 1
+  maxReplicas: 2
   metrics:
     - type: Resource
       resource:

--- a/k8s/base/summarizer/pdb.yaml
+++ b/k8s/base/summarizer/pdb.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: worker
     app.kubernetes.io/part-of: feedforge
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: summarizer

--- a/k8s/base/summarizer/pdb.yaml
+++ b/k8s/base/summarizer/pdb.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: summarizer
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: summarizer
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/part-of: feedforge
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: summarizer

--- a/terraform/modules/gke/main.tf
+++ b/terraform/modules/gke/main.tf
@@ -40,6 +40,14 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  maintenance_policy {
+    recurring_window {
+      start_time = var.maintenance_start_time
+      end_time   = var.maintenance_end_time
+      recurrence = var.maintenance_recurrence
+    }
+  }
+
   deletion_protection = false
 }
 
@@ -85,7 +93,13 @@ resource "google_container_node_pool" "primary" {
     auto_upgrade = true
   }
 
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+  }
+
   lifecycle {
+    ignore_changes       = [node_count]
     replace_triggered_by = [google_container_cluster.primary.id]
   }
 }

--- a/terraform/modules/gke/variables.tf
+++ b/terraform/modules/gke/variables.tf
@@ -40,7 +40,7 @@ variable "services_range_name" {
 
 variable "machine_type" {
   type    = string
-  default = "e2-medium"
+  default = "e2-standard-2"
 }
 
 variable "disk_size_gb" {
@@ -65,7 +65,7 @@ variable "min_node_count" {
 
 variable "max_node_count" {
   type    = number
-  default = 3
+  default = 4
 }
 
 variable "node_service_account" {
@@ -76,4 +76,22 @@ variable "node_service_account" {
 variable "environment" {
   type        = string
   description = "Environment name (e.g. dev, staging, prod)"
+}
+
+variable "maintenance_start_time" {
+  type        = string
+  description = "Maintenance window start time (RFC 3339)"
+  default     = "2026-01-01T02:00:00Z"
+}
+
+variable "maintenance_end_time" {
+  type        = string
+  description = "Maintenance window end time (RFC 3339)"
+  default     = "2026-01-01T06:00:00Z"
+}
+
+variable "maintenance_recurrence" {
+  type        = string
+  description = "Maintenance window recurrence (RFC 5545 RRULE)"
+  default     = "FREQ=DAILY"
 }


### PR DESCRIPTION
## Summary
- ResourceQuota and LimitRange on feedforge namespace
- PodDisruptionBudget (maxUnavailable: 1) on backend, frontend, summarizer
- Native sidecar container (log-exporter) on backend deployment
- GKE maintenance window (daily 02:00–06:00 UTC)
- Surge upgrade strategy (max_surge=1, max_unavailable=0)
- Upgrade node machine type from e2-medium to e2-standard-2
- Terraform lifecycle: ignore node_count drift from cluster autoscaler
- Update all image tags to phase-5-rbac-wi-2-g1369e4e
- Bump summarizer HPA max to 2

## K8s Concepts Covered
ResourceQuota, LimitRange, PodDisruptionBudget, native sidecar containers, maintenance windows, surge upgrade strategy

## Test plan
- [x] `kubectl describe resourcequota -n feedforge`
- [x] `kubectl describe limitrange -n feedforge`
- [x] `kubectl get pdb -n feedforge`
- [x] `kubectl get pods -n feedforge -l app.kubernetes.io/name=backend` (2/2 containers)
- [x] `terraform apply` completes with maintenance window and surge upgrade
- [x] Node pool upgrade completes without PDB deadlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)