### PR TITLE
feat: add Prometheus, Grafana, and custom metric HPA

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,12 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.routers import articles, feeds, health
+from app.middleware import PrometheusMiddleware
+from app.routers import articles, feeds, health, metrics
 
 app = FastAPI(title="FeedForge", version="0.1.0")
 
+app.add_middleware(PrometheusMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -15,3 +17,4 @@ app.add_middleware(
 app.include_router(health.router, prefix="/api")
 app.include_router(feeds.router, prefix="/api")
 app.include_router(articles.router, prefix="/api")
+app.include_router(metrics.router)

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -1,0 +1,19 @@
+from prometheus_client import Counter, Gauge, Histogram
+
+REQUEST_COUNT = Counter(
+    "feedforge_http_requests_total",
+    "Total HTTP requests",
+    ["method", "endpoint", "status_code"],
+)
+
+REQUEST_LATENCY = Histogram(
+    "feedforge_http_request_duration_seconds",
+    "HTTP request duration in seconds",
+    ["method", "endpoint"],
+)
+
+REQUESTS_IN_PROGRESS = Gauge(
+    "feedforge_http_requests_in_progress",
+    "Number of HTTP requests currently being processed",
+    ["method"],
+)

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -1,4 +1,17 @@
+import logging
+
+import redis
 from prometheus_client import Counter, Gauge, Histogram
+from sqlalchemy import func, select
+
+from app.config import settings
+from app.database import SessionLocal
+from app.models.article import Article
+from app.models.feed import Feed
+
+logger = logging.getLogger(__name__)
+
+# --- HTTP metrics ---
 
 REQUEST_COUNT = Counter(
     "feedforge_http_requests_total",
@@ -17,3 +30,49 @@ REQUESTS_IN_PROGRESS = Gauge(
     "Number of HTTP requests currently being processed",
     ["method"],
 )
+
+# --- Business metrics ---
+
+FEEDS_TOTAL = Gauge("feedforge_feeds_total", "Total number of registered feeds")
+FEEDS_ACTIVE = Gauge("feedforge_feeds_active", "Number of active feeds")
+ARTICLES_TOTAL = Gauge("feedforge_articles_total", "Total articles fetched")
+ARTICLES_SUMMARIZED = Gauge("feedforge_articles_summarized", "Articles with AI summaries")
+ARTICLES_DIGEST_SENT = Gauge("feedforge_articles_digest_sent", "Articles sent via digest")
+QUEUE_LENGTH = Gauge("feedforge_queue_length", "Articles waiting in Redis queue")
+
+QUEUE_KEY = "feedforge:articles:pending"
+
+
+def collect_business_metrics() -> None:
+    """Query PostgreSQL and Redis to update business metric gauges."""
+    try:
+        db = SessionLocal()
+        try:
+            FEEDS_TOTAL.set(db.scalar(select(func.count()).select_from(Feed)) or 0)
+            FEEDS_ACTIVE.set(
+                db.scalar(select(func.count()).select_from(Feed).where(Feed.is_active.is_(True))) or 0
+            )
+            ARTICLES_TOTAL.set(db.scalar(select(func.count()).select_from(Article)) or 0)
+            ARTICLES_SUMMARIZED.set(
+                db.scalar(
+                    select(func.count()).select_from(Article).where(Article.summary.is_not(None))
+                ) or 0
+            )
+            ARTICLES_DIGEST_SENT.set(
+                db.scalar(
+                    select(func.count()).select_from(Article).where(Article.digest_sent_at.is_not(None))
+                ) or 0
+            )
+        finally:
+            db.close()
+    except Exception:
+        logger.warning("Failed to collect DB metrics", exc_info=True)
+
+    try:
+        r = redis.Redis(
+            host=settings.redis_host, port=settings.redis_port, db=settings.redis_db,
+        )
+        QUEUE_LENGTH.set(r.llen(QUEUE_KEY))
+        r.close()
+    except Exception:
+        logger.warning("Failed to collect Redis metrics", exc_info=True)

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -1,0 +1,46 @@
+import re
+import time
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.metrics import REQUEST_COUNT, REQUEST_LATENCY, REQUESTS_IN_PROGRESS
+
+# Normalize numeric path segments to prevent cardinality explosion
+_ID_PATTERN = re.compile(r"/\d+")
+
+
+def _normalize_path(path: str) -> str:
+    return _ID_PATTERN.sub("/{id}", path)
+
+
+class PrometheusMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:  # noqa: ANN001
+        if request.url.path == "/metrics":
+            return await call_next(request)
+
+        method = request.method
+        REQUESTS_IN_PROGRESS.labels(method=method).inc()
+        start = time.perf_counter()
+
+        try:
+            response = await call_next(request)
+        except Exception:
+            REQUEST_COUNT.labels(
+                method=method,
+                endpoint=_normalize_path(request.url.path),
+                status_code="500",
+            ).inc()
+            raise
+        finally:
+            duration = time.perf_counter() - start
+            REQUESTS_IN_PROGRESS.labels(method=method).dec()
+
+        endpoint = _normalize_path(request.url.path)
+        REQUEST_COUNT.labels(
+            method=method, endpoint=endpoint, status_code=str(response.status_code)
+        ).inc()
+        REQUEST_LATENCY.labels(method=method, endpoint=endpoint).observe(duration)
+
+        return response

--- a/backend/app/routers/metrics.py
+++ b/backend/app/routers/metrics.py
@@ -2,9 +2,12 @@ from fastapi import APIRouter
 from fastapi.responses import Response
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
+from app.metrics import collect_business_metrics
+
 router = APIRouter()
 
 
 @router.get("/metrics")
 def metrics() -> Response:
+    collect_business_metrics()
     return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/backend/app/routers/metrics.py
+++ b/backend/app/routers/metrics.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+from fastapi.responses import Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+router = APIRouter()
+
+
+@router.get("/metrics")
+def metrics() -> Response:
+    return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/backend/app/summarizer.py
+++ b/backend/app/summarizer.py
@@ -17,6 +17,8 @@ logger = logging.getLogger(__name__)
 
 QUEUE_KEY = "feedforge:articles:pending"
 BRPOP_TIMEOUT = 30
+REQUEST_DELAY = 1.0
+MAX_RETRIES = 5
 
 SYSTEM_PROMPT = (
     "You are a concise article summarizer. "
@@ -68,35 +70,49 @@ def summarize_article(article: Article, client: genai.Client) -> str | None:
     user_message = f"Title: {article.title}\n\nContent:\n{content}"
     system_prompt = SYSTEM_PROMPT.format(max_chars=max_chars)
 
-    try:
-        response = client.models.generate_content(
-            model=settings.llm_model,
-            contents=user_message,
-            config=genai.types.GenerateContentConfig(
-                system_instruction=system_prompt,
-                max_output_tokens=256,
-                temperature=0.3,
-                thinking_config=genai.types.ThinkingConfig(thinking_budget=0),
-            ),
-        )
-        summary = response.text
-        if len(summary) > max_chars:
-            logger.warning(
-                "Summary for article %s exceeded %d chars (%d), truncating",
-                article.id, max_chars, len(summary),
+    for attempt in range(MAX_RETRIES):
+        try:
+            response = client.models.generate_content(
+                model=settings.llm_model,
+                contents=user_message,
+                config=genai.types.GenerateContentConfig(
+                    system_instruction=system_prompt,
+                    max_output_tokens=256,
+                    temperature=0.3,
+                    thinking_config=genai.types.ThinkingConfig(thinking_budget=0),
+                ),
             )
-            last_period = summary.rfind(".", 0, max_chars)
-            summary = summary[:last_period + 1] if last_period > 0 else summary[:max_chars]
-        return summary
-    except Exception:
-        logger.exception("Gemini API error for article %s", article.id)
-        return None
+            summary = response.text
+            if len(summary) > max_chars:
+                logger.warning(
+                    "Summary for article %s exceeded %d chars (%d), truncating",
+                    article.id, max_chars, len(summary),
+                )
+                last_period = summary.rfind(".", 0, max_chars)
+                summary = summary[:last_period + 1] if last_period > 0 else summary[:max_chars]
+            return summary
+        except genai.errors.ClientError as exc:
+            if exc.status_code == 429 and attempt < MAX_RETRIES - 1:
+                wait = 2 ** attempt
+                logger.warning("Rate limited on article %s, retrying in %ds (attempt %d/%d)",
+                               article.id, wait, attempt + 1, MAX_RETRIES)
+                time.sleep(wait)
+                continue
+            logger.exception("Gemini API error for article %s", article.id)
+            return None
+        except Exception:
+            logger.exception("Gemini API error for article %s", article.id)
+            return None
 
 
-def backfill_unsummarized(db, redis_client: redis.Redis) -> int:
+def backfill_unsummarized(redis_client: redis.Redis) -> int:
     """Push IDs of articles missing summaries to the Redis queue."""
-    stmt = select(Article.id).where(Article.summary.is_(None))
-    article_ids = list(db.scalars(stmt).all())
+    db = SessionLocal()
+    try:
+        stmt = select(Article.id).where(Article.summary.is_(None))
+        article_ids = list(db.scalars(stmt).all())
+    finally:
+        db.close()
 
     if not article_ids:
         return 0
@@ -108,7 +124,7 @@ def backfill_unsummarized(db, redis_client: redis.Redis) -> int:
     return len(article_ids)
 
 
-def process_one(article_id_str: str, db, client: genai.Client) -> bool:
+def process_one(article_id_str: str, client: genai.Client) -> bool:
     """Fetch article, summarize, and write back. Returns True on success."""
     try:
         article_id = uuid.UUID(article_id_str)
@@ -116,23 +132,30 @@ def process_one(article_id_str: str, db, client: genai.Client) -> bool:
         logger.warning("Invalid article ID in queue: %s", article_id_str)
         return False
 
-    article = db.get(Article, article_id)
-    if article is None:
-        logger.debug("Article %s not found (deleted?), skipping", article_id)
-        return False
+    db = SessionLocal()
+    try:
+        article = db.get(Article, article_id)
+        if article is None:
+            logger.debug("Article %s not found (deleted?), skipping", article_id)
+            return False
 
-    if article.summary is not None:
-        logger.debug("Article %s already summarized, skipping", article_id)
+        if article.summary is not None:
+            logger.debug("Article %s already summarized, skipping", article_id)
+            return True
+
+        summary = summarize_article(article, client)
+        if summary is None:
+            return False
+
+        article.summary = summary
+        db.commit()
+        logger.info("Summarized article %s: %s", article.id, article.title[:80])
         return True
-
-    summary = summarize_article(article, client)
-    if summary is None:
-        return False
-
-    article.summary = summary
-    db.commit()
-    logger.info("Summarized article %s: %s", article.id, article.title[:80])
-    return True
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
 
 
 def main() -> None:
@@ -153,34 +176,30 @@ def main() -> None:
     client = get_llm_client()
     logger.info("Vertex AI client ready (project=%s, location=%s)", settings.gcp_project_id, settings.gcp_location)
 
-    db = SessionLocal()
-    try:
-        backfill_unsummarized(db, redis_client)
+    backfill_unsummarized(redis_client)
 
-        processed = 0
-        errors = 0
-        start = time.monotonic()
+    processed = 0
+    errors = 0
+    start = time.monotonic()
 
-        while not _shutdown:
-            result = redis_client.brpop(QUEUE_KEY, timeout=BRPOP_TIMEOUT)
-            if result is None:
-                continue
+    while not _shutdown:
+        result = redis_client.brpop(QUEUE_KEY, timeout=BRPOP_TIMEOUT)
+        if result is None:
+            continue
 
-            _, article_id_str = result
-            try:
-                if process_one(article_id_str, db, client):
-                    processed += 1
-                else:
-                    errors += 1
-            except Exception:
-                logger.exception("Unexpected error processing article %s", article_id_str)
-                db.rollback()
+        _, article_id_str = result
+        try:
+            if process_one(article_id_str, client):
+                processed += 1
+            else:
                 errors += 1
+        except Exception:
+            logger.exception("Unexpected error processing article %s", article_id_str)
+            errors += 1
+        time.sleep(REQUEST_DELAY)
 
-        elapsed = time.monotonic() - start
-        logger.info("Summarizer shutting down: %d processed, %d errors (%.1fs)", processed, errors, elapsed)
-    finally:
-        db.close()
+    elapsed = time.monotonic() - start
+    logger.info("Summarizer shutting down: %d processed, %d errors (%.1fs)", processed, errors, elapsed)
 
 
 if __name__ == "__main__":

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,4 +14,5 @@ dependencies = [
     "redis>=5.0,<6",
     "google-genai>=1.0,<2",
     "httpx>=0.28,<1",
+    "prometheus-client>=0.21,<1",
 ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -295,6 +295,7 @@ dependencies = [
     { name = "feedparser" },
     { name = "google-genai" },
     { name = "httpx" },
+    { name = "prometheus-client" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings" },
     { name = "redis" },
@@ -309,6 +310,7 @@ requires-dist = [
     { name = "feedparser", specifier = ">=6.0,<7" },
     { name = "google-genai", specifier = ">=1.0,<2" },
     { name = "httpx", specifier = ">=0.28,<1" },
+    { name = "prometheus-client", specifier = ">=0.21,<1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2,<4" },
     { name = "pydantic-settings", specifier = ">=2.7,<3" },
     { name = "redis", specifier = ">=5.0,<6" },
@@ -554,6 +556,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
 ]
 
 [[package]]

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -68,7 +68,7 @@
 - [x] `gcloud container clusters get-credentials` → verify kubectl access
 - [x] Deploy nginx pod + LoadBalancer Service manually
 - [x] Verify external access
-- [ ] `terraform destroy` (keeping cluster running, ~$2/day)
+- [x] `terraform destroy` (keeping cluster running, ~$2/day)
 
 ## Phase 1: Core Application (Backend + DB)
 **Goal**: FastAPI backend + PostgreSQL running in cluster, CRUD for feeds and articles working.
@@ -113,7 +113,7 @@
 - [x] Set up Cloud Build trigger on GitHub push to main (Terraform module)
 - [x] Write skaffold.yaml for local dev loop
 - [x] Configure rolling update strategy on Deployments
-- [ ] Verify full CI/CD: push code → auto-deploy → verify in browser
+- [x] Verify full CI/CD: push code → auto-deploy → verify in browser
 
 ## Phase 4: Scaling & Notifications
 **Goal**: Daily digest notifications, autoscaling under load.
@@ -143,7 +143,7 @@
 - [x] Add GKE maintenance window (daily 02:00–06:00 UTC via Terraform)
 - [x] Add surge upgrade strategy (max_surge=1, max_unavailable=0)
 - [x] Upgrade node machine type to e2-standard-2
-- [ ] Set up Prometheus + basic monitoring (stretch)
+- [x] Set up Prometheus + basic monitoring (stretch)
 
 ## Cost Budget
 

--- a/k8s/base/grafana/configmap-dashboard-provider.yaml
+++ b/k8s/base/grafana/configmap-dashboard-provider.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-provider
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: feedforge
+        type: file
+        disableDeletion: true
+        options:
+          path: /etc/grafana/dashboards

--- a/k8s/base/grafana/configmap-dashboard.yaml
+++ b/k8s/base/grafana/configmap-dashboard.yaml
@@ -110,3 +110,104 @@ data:
       "title": "FeedForge Backend",
       "uid": "feedforge-backend"
     }
+  feedforge-pipeline.json: |
+    {
+      "annotations": { "list": [] },
+      "editable": false,
+      "graphTooltip": 1,
+      "links": [],
+      "panels": [
+        {
+          "title": "Feeds",
+          "type": "stat",
+          "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            { "expr": "feedforge_feeds_total", "legendFormat": "total" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] }
+        },
+        {
+          "title": "Active Feeds",
+          "type": "stat",
+          "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            { "expr": "feedforge_feeds_active", "legendFormat": "active" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] }
+        },
+        {
+          "title": "Articles Fetched",
+          "type": "stat",
+          "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            { "expr": "feedforge_articles_total", "legendFormat": "fetched" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] }
+        },
+        {
+          "title": "Articles Summarized",
+          "type": "stat",
+          "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            { "expr": "feedforge_articles_summarized", "legendFormat": "summarized" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] }
+        },
+        {
+          "title": "Redis Queue Length",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            { "expr": "feedforge_queue_length", "legendFormat": "pending articles" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "min": 0,
+              "custom": { "drawStyle": "line", "fillOpacity": 20 }
+            },
+            "overrides": []
+          }
+        },
+        {
+          "title": "Digest Sent",
+          "type": "stat",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            { "expr": "feedforge_articles_digest_sent", "legendFormat": "sent" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] }
+        },
+        {
+          "title": "Pipeline Overview",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 12 },
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            { "expr": "feedforge_articles_total", "legendFormat": "fetched" },
+            { "expr": "feedforge_articles_summarized", "legendFormat": "summarized" },
+            { "expr": "feedforge_articles_digest_sent", "legendFormat": "digest sent" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "min": 0,
+              "custom": { "drawStyle": "line", "fillOpacity": 10 }
+            },
+            "overrides": []
+          }
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": ["feedforge"],
+      "templating": { "list": [] },
+      "time": { "from": "now-6h", "to": "now" },
+      "title": "FeedForge Pipeline",
+      "uid": "feedforge-pipeline"
+    }

--- a/k8s/base/grafana/configmap-dashboard.yaml
+++ b/k8s/base/grafana/configmap-dashboard.yaml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+data:
+  feedforge-backend.json: |
+    {
+      "annotations": { "list": [] },
+      "editable": false,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "links": [],
+      "panels": [
+        {
+          "title": "Request Rate",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            {
+              "expr": "sum(rate(feedforge_http_requests_total[5m])) by (status_code)",
+              "legendFormat": "{{status_code}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "custom": { "drawStyle": "line", "fillOpacity": 10 }
+            },
+            "overrides": []
+          }
+        },
+        {
+          "title": "Request Latency (p50 / p95 / p99)",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum(rate(feedforge_http_request_duration_seconds_bucket[5m])) by (le))",
+              "legendFormat": "p50"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(feedforge_http_request_duration_seconds_bucket[5m])) by (le))",
+              "legendFormat": "p95"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(feedforge_http_request_duration_seconds_bucket[5m])) by (le))",
+              "legendFormat": "p99"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": { "drawStyle": "line", "fillOpacity": 10 }
+            },
+            "overrides": []
+          }
+        },
+        {
+          "title": "Requests In Progress",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            {
+              "expr": "sum(feedforge_http_requests_in_progress) by (method)",
+              "legendFormat": "{{method}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": { "drawStyle": "line", "fillOpacity": 10 }
+            },
+            "overrides": []
+          }
+        },
+        {
+          "title": "Error Rate (5xx)",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            {
+              "expr": "sum(rate(feedforge_http_requests_total{status_code=~\"5..\"}[5m])) / sum(rate(feedforge_http_requests_total[5m]))",
+              "legendFormat": "error ratio"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "custom": { "drawStyle": "line", "fillOpacity": 10 },
+              "max": 1,
+              "min": 0
+            },
+            "overrides": []
+          }
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": ["feedforge"],
+      "templating": { "list": [] },
+      "time": { "from": "now-1h", "to": "now" },
+      "title": "FeedForge Backend",
+      "uid": "feedforge-backend"
+    }

--- a/k8s/base/grafana/configmap-datasource.yaml
+++ b/k8s/base/grafana/configmap-datasource.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus.feedforge.svc.cluster.local:9090
+        isDefault: true
+        editable: false

--- a/k8s/base/grafana/deployment.yaml
+++ b/k8s/base/grafana/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana
+        app.kubernetes.io/component: monitoring
+        app.kubernetes.io/part-of: feedforge
+    spec:
+      serviceAccountName: grafana
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 472
+        runAsGroup: 472
+        fsGroup: 472
+      containers:
+        - name: grafana
+          image: grafana/grafana:11.5.2
+          env:
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              value: feedforge
+            - name: GF_USERS_ALLOW_SIGN_UP
+              value: "false"
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: Viewer
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 3000
+              name: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+              readOnly: true
+            - name: dashboard-provider
+              mountPath: /etc/grafana/provisioning/dashboards
+              readOnly: true
+            - name: dashboards
+              mountPath: /etc/grafana/dashboards
+              readOnly: true
+            - name: grafana-data
+              mountPath: /var/lib/grafana
+            - name: grafana-tmp
+              mountPath: /tmp
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+        - name: dashboard-provider
+          configMap:
+            name: grafana-dashboard-provider
+        - name: dashboards
+          configMap:
+            name: grafana-dashboards
+        - name: grafana-data
+          emptyDir: {}
+        - name: grafana-tmp
+          emptyDir: {}

--- a/k8s/base/grafana/service.yaml
+++ b/k8s/base/grafana/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: grafana
+  ports:
+    - port: 3000
+      targetPort: 3000
+      name: http

--- a/k8s/base/grafana/serviceaccount.yaml
+++ b/k8s/base/grafana/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+automountServiceAccountToken: false

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -41,3 +41,14 @@ resources:
   - backup/serviceaccount.yaml
   - backup/configmap.yaml
   - backup/job.yaml
+  - prometheus/serviceaccount.yaml
+  - prometheus/configmap.yaml
+  - prometheus/deployment.yaml
+  - prometheus/service.yaml
+  - prometheus/networkpolicy.yaml
+  - grafana/serviceaccount.yaml
+  - grafana/configmap-datasource.yaml
+  - grafana/configmap-dashboard-provider.yaml
+  - grafana/configmap-dashboard.yaml
+  - grafana/deployment.yaml
+  - grafana/service.yaml

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -52,3 +52,10 @@ resources:
   - grafana/configmap-dashboard.yaml
   - grafana/deployment.yaml
   - grafana/service.yaml
+  - prometheus-adapter/serviceaccount.yaml
+  - prometheus-adapter/configmap.yaml
+  - prometheus-adapter/deployment.yaml
+  - prometheus-adapter/service.yaml
+  - prometheus-adapter/clusterroles.yaml
+  - prometheus-adapter/apiservice.yaml
+  - prometheus-adapter/networkpolicy.yaml

--- a/k8s/base/namespace-quota.yaml
+++ b/k8s/base/namespace-quota.yaml
@@ -11,4 +11,4 @@ spec:
     requests.memory: 1536Mi
     limits.cpu: "3"
     limits.memory: 2560Mi
-    pods: "15"
+    pods: "17"

--- a/k8s/base/namespace-quota.yaml
+++ b/k8s/base/namespace-quota.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/part-of: feedforge
 spec:
   hard:
-    requests.cpu: "1"
-    requests.memory: 1536Mi
-    limits.cpu: "3"
-    limits.memory: 2560Mi
-    pods: "17"
+    requests.cpu: "2"
+    requests.memory: 2048Mi
+    limits.cpu: "6"
+    limits.memory: 4096Mi
+    pods: "25"

--- a/k8s/base/prometheus-adapter/apiservice.yaml
+++ b/k8s/base/prometheus-adapter/apiservice.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.external.metrics.k8s.io
+  labels:
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: feedforge
+spec:
+  service:
+    name: prometheus-adapter
+    namespace: feedforge
+  group: external.metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100

--- a/k8s/base/prometheus-adapter/clusterroles.yaml
+++ b/k8s/base/prometheus-adapter/clusterroles.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-adapter:system:auth-delegator
+  labels:
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: feedforge
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-adapter
+    namespace: feedforge
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-adapter-resource-reader
+  labels:
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: feedforge
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "namespaces"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-adapter:resource-reader
+  labels:
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: feedforge
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-adapter-resource-reader
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-adapter
+    namespace: feedforge
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-adapter-custom-metrics-server
+  labels:
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: feedforge
+rules:
+  - apiGroups: ["custom.metrics.k8s.io"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["external.metrics.k8s.io"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-adapter:custom-metrics-server
+  labels:
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: feedforge
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-adapter-custom-metrics-server
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-adapter
+    namespace: feedforge

--- a/k8s/base/prometheus-adapter/configmap.yaml
+++ b/k8s/base/prometheus-adapter/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-adapter-config
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+data:
+  config.yaml: |
+    externalRules:
+      - seriesQuery: 'feedforge_queue_length'
+        resources:
+          overrides:
+            namespace: {resource: "namespace"}
+        name:
+          matches: "^(.*)"
+          as: "${1}"
+        metricsQuery: 'feedforge_queue_length'

--- a/k8s/base/prometheus-adapter/deployment.yaml
+++ b/k8s/base/prometheus-adapter/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-adapter
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-adapter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus-adapter
+        app.kubernetes.io/component: monitoring
+        app.kubernetes.io/part-of: feedforge
+    spec:
+      serviceAccountName: prometheus-adapter
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+      containers:
+        - name: prometheus-adapter
+          image: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.12.0
+          args:
+            - --prometheus-url=http://prometheus.feedforge.svc.cluster.local:9090
+            - --metrics-relist-interval=30s
+            - --config=/etc/adapter/config.yaml
+            - --secure-port=6443
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 6443
+              name: https
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: config
+              mountPath: /etc/adapter
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            - name: certs
+              mountPath: /apiserver.local.config
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-adapter-config
+        - name: tmp
+          emptyDir: {}
+        - name: certs
+          emptyDir: {}

--- a/k8s/base/prometheus-adapter/networkpolicy.yaml
+++ b/k8s/base/prometheus-adapter/networkpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-adapter-allow-apiserver
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-adapter
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 6443

--- a/k8s/base/prometheus-adapter/rolebinding-kube-system.yaml
+++ b/k8s/base/prometheus-adapter/rolebinding-kube-system.yaml
@@ -1,0 +1,19 @@
+# Apply separately — this targets kube-system namespace and cannot go through
+# the feedforge kustomization:
+#   kubectl apply -f k8s/base/prometheus-adapter/rolebinding-kube-system.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-adapter:extension-apiserver-authentication-reader
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: feedforge
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-adapter
+    namespace: feedforge

--- a/k8s/base/prometheus-adapter/service.yaml
+++ b/k8s/base/prometheus-adapter/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-adapter
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: prometheus-adapter
+  ports:
+    - port: 443
+      targetPort: 6443
+      name: https

--- a/k8s/base/prometheus-adapter/serviceaccount.yaml
+++ b/k8s/base/prometheus-adapter/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-adapter
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+automountServiceAccountToken: true

--- a/k8s/base/prometheus/configmap.yaml
+++ b/k8s/base/prometheus/configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+
+    scrape_configs:
+      - job_name: prometheus
+        static_configs:
+          - targets: ["localhost:9090"]
+
+      - job_name: feedforge-backend
+        metrics_path: /metrics
+        static_configs:
+          - targets: ["backend.feedforge.svc.cluster.local:8000"]

--- a/k8s/base/prometheus/deployment.yaml
+++ b/k8s/base/prometheus/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/component: monitoring
+        app.kubernetes.io/part-of: feedforge
+    spec:
+      serviceAccountName: prometheus
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v3.2.1
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus"
+            - "--storage.tsdb.retention.time=3d"
+            - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+            - "--web.console.templates=/usr/share/prometheus/consoles"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 9090
+              name: http
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+              readOnly: true
+            - name: data
+              mountPath: /prometheus
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+        - name: data
+          emptyDir: {}

--- a/k8s/base/prometheus/networkpolicy.yaml
+++ b/k8s/base/prometheus/networkpolicy.yaml
@@ -18,6 +18,9 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: grafana
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus-adapter
       ports:
         - protocol: TCP
           port: 9090

--- a/k8s/base/prometheus/networkpolicy.yaml
+++ b/k8s/base/prometheus/networkpolicy.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-clients
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: grafana
+      ports:
+        - protocol: TCP
+          port: 9090

--- a/k8s/base/prometheus/service.yaml
+++ b/k8s/base/prometheus/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: prometheus
+  ports:
+    - port: 9090
+      targetPort: 9090
+      name: http

--- a/k8s/base/prometheus/serviceaccount.yaml
+++ b/k8s/base/prometheus/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: feedforge
+automountServiceAccountToken: false

--- a/k8s/base/summarizer/hpa.yaml
+++ b/k8s/base/summarizer/hpa.yaml
@@ -15,12 +15,13 @@ spec:
   minReplicas: 1
   maxReplicas: 2
   metrics:
-    - type: Resource
-      resource:
-        name: cpu
+    - type: External
+      external:
+        metric:
+          name: feedforge_queue_length
         target:
-          type: Utilization
-          averageUtilization: 70
+          type: Value
+          value: "20"
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 300


### PR DESCRIPTION
## Summary
- Deploy self-hosted Prometheus + Grafana monitoring stack with raw K8s manifests
- Instrument backend with `prometheus-client` for HTTP and business metrics (feeds, articles, queue length)
- Add Prometheus Adapter for External Metrics API, enabling HPA to scale summarizer based on Redis queue depth instead of CPU
- Fix summarizer stale DB session bug and add Gemini API rate limit retry

## K8s Concepts Covered
- ConfigMap as file mount (Prometheus config, Grafana provisioning)
- APIService / API aggregation layer
- ClusterRole / ClusterRoleBinding (cluster-scoped RBAC)
- External metric HPA (`external.metrics.k8s.io`)
- NetworkPolicy for monitoring stack

## Test plan
- [x] Prometheus scraping backend `/metrics` endpoint
- [x] Grafana dashboards auto-provisioned (Backend + Pipeline)
- [x] Prometheus Adapter serving `feedforge_queue_length` via External Metrics API
- [x] HPA scaling summarizer to 2 replicas when queue > 20
- [x] Summarizer processing articles with per-request DB sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)