### PR TITLE
chore: deploy fetcher, summarizer, digest in the local overlay (Phase 2 of #35)

### DIFF
--- a/k8s/overlays/local/kustomization.yaml
+++ b/k8s/overlays/local/kustomization.yaml
@@ -7,17 +7,22 @@ kind: Kustomization
 # See k8s/local/kind-config.yaml and scripts/local-cluster-up.sh.
 #
 # Composition:
-#   - base resources (subset — backend, frontend, redis only; fetcher /
-#     summarizer / digest / observability are deferred follow-ups)
+#   - all 7 base workloads (redis, backend, frontend, fetcher, summarizer,
+#     digest, plus CNPG postgres provisioned by the postgres-cnpg component)
 #   - postgres-cnpg component swaps Cloud SQL for in-cluster CNPG
 #   - overlay-level patches handle local-only concerns: debugpy port, HPA
-#     removal (no metrics-server in kind), DEBUG flags
+#     removal (no metrics-server / prometheus-adapter in kind), removal of
+#     CSI-mounted notification creds (no Secret-Store CSI driver in kind),
+#     DEBUG flags
 
 resources:
   - namespace.yaml
   - ../../base/redis
   - ../../base/backend
   - ../../base/frontend
+  - ../../base/fetcher
+  - ../../base/summarizer
+  - ../../base/digest
 
 components:
   - ../../components/postgres-cnpg
@@ -31,5 +36,15 @@ patches:
       metadata:
         name: backend
         namespace: feedforge
+  # Delete the summarizer HPA — uses an External metric (queue length via
+  # prometheus-adapter), which isn't installed in the local kind cluster.
+  - patch: |
+      $patch: delete
+      apiVersion: autoscaling/v2
+      kind: HorizontalPodAutoscaler
+      metadata:
+        name: summarizer
+        namespace: feedforge
   - path: patches/backend-config-patch.yaml
   - path: patches/backend-service-patch.yaml
+  - path: patches/digest-patch.yaml

--- a/k8s/overlays/local/patches/digest-patch.yaml
+++ b/k8s/overlays/local/patches/digest-patch.yaml
@@ -1,0 +1,24 @@
+# Strip the notification-credentials Secret-Store CSI volume from the
+# daily-digest CronJob. The CSI driver isn't installed in kind, so the
+# volume mount would fail. The container's secretKeyRef env vars
+# (NOTIFICATION_WEBHOOK_URL, LINE_*) are marked optional: true and resolve
+# to empty when the Secret doesn't exist — digest will run but won't
+# actually send notifications, which is fine for local development.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: daily-digest
+  namespace: feedforge
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: digest
+              volumeMounts:
+                - name: notification-creds
+                  $patch: delete
+          volumes:
+            - name: notification-creds
+              $patch: delete


### PR DESCRIPTION
## Summary

Phase 2 of [#35](https://github.com/huchka/feedforge/issues/35). Adds the worker pipeline (fetcher / summarizer / digest) to the local kind overlay so the full 7-workload topology runs locally — better fidelity for catching bugs in the fetcher → summarizer → digest seam, not just the request path.

## What changed

- \`k8s/overlays/local/kustomization.yaml\` includes \`../../base/{fetcher,summarizer,digest}\`
- Inline patch deletes the summarizer HPA (External metric via prometheus-adapter; not in kind — same reason backend HPA is deleted)
- New \`patches/digest-patch.yaml\` strips the \`notification-credentials\` Secret-Store CSI volume (CSI driver isn't in kind). The container's env vars referencing that Secret are \`optional: true\` and resolve to empty.

After Phase 1 ([#36](https://github.com/huchka/feedforge/pull/36)), the cloud-sql-proxy + postgres-creds stack is no longer in base, so the worker manifests are portable to kind without any per-workload patches for that.

postgres-cnpg's existing \`FEEDFORGE_DB_HOST=feedforge-db-rw\` override on \`backend-config\` flows automatically to all four DB-using workloads via shared \`envFrom\`.

## Test plan

- [x] \`kubectl kustomize k8s/overlays/local\` renders 22 valid resources (\`kubeconform -strict\`, 0 invalid)
- [x] \`make deploy-local\` brings up all 7 workloads on kind:
  - 4 Deployments: backend, frontend, redis, summarizer (all \`1/1 Running\`)
  - 2 CronJobs: feed-fetcher (\`0 23 * * *\`), daily-digest (\`30 23 * * *\`)
  - 1 CNPG Cluster: feedforge-db (1 instance, healthy)
- [x] Manually triggered \`feed-fetcher\` CronJob: completed in 32s — connected to Redis, queried DB, processed 0 feeds (DB empty)
- [x] Summarizer logs: \`Summarizer worker starting\` → connected to Redis → Vertex AI client ready
- [ ] CI \`validate-manifests\` job passes

## Known runtime limitation

The \`daily-digest\` CronJob will fail when its schedule fires (23:30 UTC) because the app hardcodes \`FEEDFORGE_DIGEST_PROVIDER: \"line\"\` and there are no LINE credentials in local. The CronJob is still deployed (counts toward Phase 2's \"all 7 workloads come up\"), but successful execution requires either a stub Secret or a no-op provider mode — deferred to a follow-up. Acknowledged trade-off, not a regression: digest never worked in local before this PR either, since the workload wasn't deployed.

Refs #35 — Phase 3 (monitoring in local) follows as the final PR.