### PR TITLE
chore: add monitoring component to the local overlay (Phase 3 of #35)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 	@echo "  make cluster-down      Delete the cluster"
 	@echo "  make deploy-local      skaffold run -p local (one-shot deploy)"
 	@echo "  make dev-local         skaffold dev -p local (watch + redeploy)"
-	@echo "  make port-forward      backend :8000, debugpy :5678, frontend :8080"
+	@echo "  make port-forward      backend :8000, debugpy :5678, frontend :8080, grafana :3000, prometheus :9090"
 	@echo ""
 	@echo "Hybrid — Tier 1 against real Cloud SQL:"
 	@echo "  make use-cloudsql      Run Cloud SQL Auth Proxy on localhost:5433"
@@ -38,11 +38,14 @@ dev-local:
 # Foreground; Ctrl-C tears all three down. Use after `make deploy-local`
 # (skaffold run drops port-forwards on exit; skaffold dev keeps them).
 port-forward:
-	@echo "==> Forwarding backend :8000, debugpy :5678, frontend :8080 (Ctrl-C to stop)"
+	@echo "==> Forwarding backend :8000, debugpy :5678, frontend :8080,"
+	@echo "    grafana :3000, prometheus :9090 (Ctrl-C to stop)"
 	@trap 'kill 0' EXIT INT TERM; \
-		kubectl port-forward -n feedforge svc/backend  8000:8000 & \
-		kubectl port-forward -n feedforge svc/backend  5678:5678 & \
-		kubectl port-forward -n feedforge svc/frontend 8080:8080 & \
+		kubectl port-forward -n feedforge svc/backend    8000:8000 & \
+		kubectl port-forward -n feedforge svc/backend    5678:5678 & \
+		kubectl port-forward -n feedforge svc/frontend   8080:8080 & \
+		kubectl port-forward -n feedforge svc/grafana    3000:3000 & \
+		kubectl port-forward -n feedforge svc/prometheus 9090:9090 & \
 		wait
 
 use-cloudsql:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -89,16 +89,38 @@ make deploy-local
 
 ### What's in the local overlay
 
-This first cut includes **backend + frontend + redis + an in-cluster CNPG Postgres**. NetworkPolicy is enforced (Calico), so you can verify policies work before pushing to GKE.
+The full app pipeline plus the observability stack:
 
-Not yet in the local overlay (handled only on the GKE dev cluster):
+- **App**: backend, frontend, redis, fetcher (CronJob), summarizer, digest (CronJob)
+- **Database**: in-cluster CNPG Postgres (`feedforge-db` Cluster, single primary)
+- **Observability**: Prometheus + Grafana + kube-state-metrics (via the `monitoring` Component)
 
-- `fetcher` / `summarizer` / `digest` workloads — need Cloud SQL Proxy and CSI patches
-- Observability stack (Prometheus / Grafana / kube-state-metrics)
+NetworkPolicy is enforced (Calico), so you can verify policies work before pushing to GKE.
+
+Not in the local overlay (handled only on the GKE dev cluster):
+
+- HPA (kind has no metrics-server / prometheus-adapter by default — backend and summarizer HPAs are deleted in the overlay)
+- `monitoring-hpa-bridge` Component (prometheus-adapter; needs cross-namespace RBAC bootstrap that's painful in kind)
+- LINE notification credentials for digest (the CronJob is deployed but will fail at the schedule unless you add a stub Secret)
 - Gateway / Ingress
-- HPA (kind has no metrics-server by default)
 
-These are tracked as follow-up work.
+### Accessing Grafana and Prometheus
+
+`make port-forward` now forwards the monitoring UIs alongside the app:
+
+| URL | What |
+|-----|------|
+| http://localhost:8080 | Frontend |
+| http://localhost:8000 | Backend API |
+| http://localhost:3000 | Grafana — login `admin` / `feedforge` |
+| http://localhost:9090 | Prometheus UI |
+
+Grafana ships with the FeedForge backend dashboard preloaded (under "Dashboards" in the sidebar). The Prometheus datasource is auto-configured to scrape Prometheus at `http://prometheus.feedforge.svc.cluster.local:9090`.
+
+Useful Prometheus queries to try at `localhost:9090/graph`:
+- `up` — which targets are scraping successfully
+- `feedforge_http_requests_total` — backend request counter (hit a few endpoints first)
+- `kube_pod_status_phase{namespace="feedforge"}` — pod phase counts via kube-state-metrics
 
 ## Tier 3 — GKE dev cluster
 

--- a/k8s/overlays/local/kustomization.yaml
+++ b/k8s/overlays/local/kustomization.yaml
@@ -10,6 +10,9 @@ kind: Kustomization
 #   - all 7 base workloads (redis, backend, frontend, fetcher, summarizer,
 #     digest, plus CNPG postgres provisioned by the postgres-cnpg component)
 #   - postgres-cnpg component swaps Cloud SQL for in-cluster CNPG
+#   - monitoring component adds Prometheus + Grafana + kube-state-metrics
+#     (without monitoring-hpa-bridge — prometheus-adapter requires a
+#     cross-namespace RBAC bootstrap that's painful in kind)
 #   - overlay-level patches handle local-only concerns: debugpy port, HPA
 #     removal (no metrics-server / prometheus-adapter in kind), removal of
 #     CSI-mounted notification creds (no Secret-Store CSI driver in kind),
@@ -26,6 +29,7 @@ resources:
 
 components:
   - ../../components/postgres-cnpg
+  - ../../components/monitoring
 
 patches:
   # Delete the backend HPA — kind has no metrics-server by default


### PR DESCRIPTION
## Summary

Final phase of [#35](https://github.com/huchka/feedforge/issues/35). Adds the existing \`monitoring\` Component (Prometheus + Grafana + kube-state-metrics) to the local kind overlay so the observability stack exercises locally — matches what dev/prod look like and lets you iterate on dashboards without round-tripping to GKE.

Skips \`monitoring-hpa-bridge\` (prometheus-adapter) per the issue: it needs a cross-namespace RBAC bootstrap that's painful in kind, and there are no HPAs in the local overlay anyway (both backend and summarizer HPAs are deleted).

## What changed

- \`k8s/overlays/local/kustomization.yaml\` adds \`../../components/monitoring\` to its components list.
- \`make port-forward\` now also forwards Grafana :3000 and Prometheus :9090 alongside backend / debugpy / frontend.
- \`docs/local-development.md\` "What's in the local overlay" section was stale (predated Phases 1 & 2 too); now reflects current reality and documents Grafana login + a few useful Prometheus queries to try.

## Closes the three-phase migration

| Phase | PR | What |
|---|---|---|
| 1 | [#36](https://github.com/huchka/feedforge/pull/36) | Extract \`postgres-cloudsql\` Component, strip Cloud SQL concerns from base |
| 2 | [#37](https://github.com/huchka/feedforge/pull/37) | Add fetcher/summarizer/digest to local overlay |
| 3 | this PR | Add monitoring stack to local overlay |

## Test plan

- [x] \`kubectl kustomize k8s/overlays/local\` renders 42 valid resources (\`kubeconform -strict\`, 0 invalid)
- [x] \`make deploy-local\` brings up the monitoring stack alongside the 7 app workloads — all 10 pods \`1/1 Running\`
- [x] Prometheus reports all **6 active targets as \`up\`**:
  - \`feedforge-backend\` (the app's \`/metrics\` endpoint)
  - \`kube-state-metrics\`
  - \`kubelet-cadvisor\` × 3 (one per kind node: control-plane, worker, worker2)
  - \`prometheus\` self-scrape
- [x] \`make port-forward\` lights up grafana on http://localhost:3000 (login \`admin\` / \`feedforge\`) and prometheus on http://localhost:9090
- [ ] CI \`validate-manifests\` job passes

## Closes #35