### PR TITLE
chore: enable daily-digest in local overlay via plain Secret

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,16 @@ jobs:
       - name: Set up kubectl
         uses: azure/setup-kubectl@v4
 
+      # The local overlay references secret-notification.yaml, which is
+      # gitignored (each developer fills in real LINE creds locally). For CI
+      # render-only validation, copy the committed .example to the expected
+      # path. Stubs are fine here -- we never apply the rendered manifest.
+      - name: Bootstrap local secrets (placeholder)
+        if: matrix.overlay == 'local'
+        run: |
+          cp k8s/overlays/local/secret-notification.yaml.example \
+             k8s/overlays/local/secret-notification.yaml
+
       - name: Render overlay
         run: |
           kubectl kustomize k8s/overlays/${{ matrix.overlay }} > rendered.yaml

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -101,8 +101,52 @@ Not in the local overlay (handled only on the GKE dev cluster):
 
 - HPA (kind has no metrics-server / prometheus-adapter by default — backend and summarizer HPAs are deleted in the overlay)
 - `monitoring-hpa-bridge` Component (prometheus-adapter; needs cross-namespace RBAC bootstrap that's painful in kind)
-- LINE notification credentials for digest (the CronJob is deployed but will fail at the schedule unless you add a stub Secret)
+- Secret-Store CSI driver (notification credentials come from a developer-provided plain Secret — see *Local notification credentials* below)
 - Gateway / Ingress
+
+### Local notification credentials
+
+The daily-digest CronJob pushes a summary to LINE (or Slack). Locally there's no Secret-Store CSI driver, so credentials live in a plain K8s Secret you provide yourself. The file is gitignored (`.gitignore` rule `k8s/**/secret-*.yaml`); only the `.example` template is committed.
+
+One-time setup:
+
+```bash
+cp k8s/overlays/local/secret-notification.yaml.example \
+   k8s/overlays/local/secret-notification.yaml
+# edit secret-notification.yaml with real values
+```
+
+How to get a LINE channel access token + user-id:
+
+1. [LINE Developers Console](https://developers.line.biz/console/) → create a Messaging API channel
+2. *Channel access token (long-lived)* → `LINE_CHANNEL_TOKEN`
+3. *Basic settings* tab → your LINE user ID → `LINE_USER_ID`
+
+The base CronJob hardcodes `FEEDFORGE_DIGEST_PROVIDER=line`. To use Slack instead, fill `NOTIFICATION_WEBHOOK_URL` and add a configmap patch overriding the provider env var.
+
+Verify end-to-end without waiting for 23:30 UTC:
+
+```bash
+# Trigger an immediate run
+kubectl create job --from=cronjob/daily-digest \
+  -n feedforge digest-test-$(date +%s)
+
+# Watch it complete
+kubectl get jobs -n feedforge -w
+
+# Inspect logs (or check your LINE / Slack for the message)
+kubectl logs -n feedforge -l job-name=digest-test-<timestamp>
+```
+
+Pod should exit `Completed`. If creds are wrong (stub `REPLACE_ME` values), the pod gets past startup but fails at the HTTP call to the LINE API and exits `Error` — informative, not a crashloop.
+
+If you forget the copy step, `make deploy-local` fails at kustomize render time:
+
+```
+Error: accumulating resources: ... no such file or directory
+```
+
+That's intentional — the failure surfaces missing creds at deploy time, not at 23:30 UTC.
 
 ### Accessing Grafana and Prometheus
 

--- a/k8s/overlays/local/kustomization.yaml
+++ b/k8s/overlays/local/kustomization.yaml
@@ -15,8 +15,9 @@ kind: Kustomization
 #     cross-namespace RBAC bootstrap that's painful in kind)
 #   - overlay-level patches handle local-only concerns: debugpy port, HPA
 #     removal (no metrics-server / prometheus-adapter in kind), removal of
-#     CSI-mounted notification creds (no Secret-Store CSI driver in kind),
-#     DEBUG flags
+#     CSI-mounted notification creds volume (no Secret-Store CSI driver in
+#     kind -- creds come from a developer-provided plain Secret instead;
+#     see secret-notification.yaml.example), DEBUG flags
 
 resources:
   - namespace.yaml
@@ -26,6 +27,13 @@ resources:
   - ../../base/fetcher
   - ../../base/summarizer
   - ../../base/digest
+  # Real notification credentials for local digest testing. The file is
+  # gitignored (see .gitignore: k8s/**/secret-*.yaml); each developer copies
+  # secret-notification.yaml.example -> secret-notification.yaml and fills in
+  # real LINE channel token + user-id (or Slack webhook). See
+  # docs/local-development.md for setup. `kubectl kustomize` will fail until
+  # the .yaml exists -- that's intentional, so missing creds surface early.
+  - secret-notification.yaml
 
 components:
   - ../../components/postgres-cnpg

--- a/k8s/overlays/local/secret-notification.yaml.example
+++ b/k8s/overlays/local/secret-notification.yaml.example
@@ -1,0 +1,35 @@
+# Template for local notification credentials.
+#
+# One-time per developer:
+#   cp k8s/overlays/local/secret-notification.yaml.example \
+#      k8s/overlays/local/secret-notification.yaml
+#   # then edit the .yaml with real values
+#
+# `secret-notification.yaml` is gitignored (matches .gitignore rule
+# `k8s/**/secret-*.yaml`). The .example template here is allowed by
+# `!k8s/**/secret-*.yaml.example`.
+#
+# To get a LINE channel token + user-id:
+#   1. LINE Developers Console -> create a Messaging API channel
+#   2. Channel access token (long-lived) -> LINE_CHANNEL_TOKEN
+#   3. Your LINE user ID (from "Basic settings" tab) -> LINE_USER_ID
+#
+# To use Slack instead of LINE locally, also override the provider env in a
+# configmap patch -- the base CronJob hardcodes FEEDFORGE_DIGEST_PROVIDER=line.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: notification-credentials
+  namespace: feedforge
+  labels:
+    app.kubernetes.io/name: notification-credentials
+    app.kubernetes.io/component: secrets
+    app.kubernetes.io/part-of: feedforge
+type: Opaque
+stringData:
+  # Slack webhook URL (only used when FEEDFORGE_DIGEST_PROVIDER=slack)
+  NOTIFICATION_WEBHOOK_URL: "https://hooks.slack.com/services/REPLACE_ME"
+  # LINE Messaging API channel access token (long-lived)
+  LINE_CHANNEL_TOKEN: "REPLACE_ME"
+  # Your LINE user ID (target of the digest push message)
+  LINE_USER_ID: "REPLACE_ME"


### PR DESCRIPTION
## Summary

- Adds `k8s/overlays/local/secret-notification.yaml.example` template with `REPLACE_ME` placeholders + LINE setup instructions; real `secret-notification.yaml` is gitignored per existing `.gitignore` rule (`k8s/**/secret-*.yaml`).
- Wires `secret-notification.yaml` into the local overlay's `resources:` so `make deploy-local` provisions the `notification-credentials` Secret in-cluster.
- Documents the one-time copy-and-fill workflow + manual digest verification recipe in `docs/local-development.md`.
- No backend code change — same `secretKeyRef` env var resolution as GKE; only the source of the Secret differs (developer-provided plain Secret in local vs. CSI-synced from GCP Secret Manager on GKE).

Mirrors the existing `components/postgres-cnpg/credentials.yaml` plain-Secret pattern. Decision recorded in [#39](https://github.com/huchka/feedforge/issues/39#issuecomment-4334547730) (Option 4: real credentials via gitignored overlay).

## Test plan

- [x] `kubectl kustomize k8s/overlays/local` renders successfully
- [x] `kubeconform` validation passes (43 valid, 0 invalid)
- [x] `kubectl kustomize k8s/overlays/dev` still renders (no regression)
- [x] After `make deploy-local`, `kubectl get secret -n feedforge` shows `notification-credentials` with 3 keys
- [x] Manual trigger (`kubectl create job --from=cronjob/daily-digest ...`) sends a real LINE message and pod exits `Completed`

Closes #39