### PR TITLE
chore: read DB & notification creds from CSI files

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,22 +1,43 @@
+from urllib.parse import quote_plus
+
+import psycopg
 from alembic import context
 from sqlalchemy import create_engine, pool
 
 from app.config import settings
 from app.models import Base
+from app.secrets import get_db_credentials
 
 target_metadata = Base.metadata
 
 
-def run_migrations_offline() -> None:
-    context.configure(
-        url=settings.database_url, target_metadata=target_metadata, literal_binds=True
+def _connect() -> psycopg.Connection:
+    user, password = get_db_credentials()
+    return psycopg.connect(
+        host=settings.db_host,
+        port=settings.db_port,
+        dbname=settings.db_name,
+        user=user,
+        password=password,
     )
+
+
+def _offline_url() -> str:
+    user, password = get_db_credentials()
+    return (
+        f"postgresql+psycopg://{quote_plus(user)}:{quote_plus(password)}"
+        f"@{settings.db_host}:{settings.db_port}/{settings.db_name}"
+    )
+
+
+def run_migrations_offline() -> None:
+    context.configure(url=_offline_url(), target_metadata=target_metadata, literal_binds=True)
     with context.begin_transaction():
         context.run_migrations()
 
 
 def run_migrations_online() -> None:
-    connectable = create_engine(settings.database_url, poolclass=pool.NullPool)
+    connectable = create_engine("postgresql+psycopg://", creator=_connect, poolclass=pool.NullPool)
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)
         with context.begin_transaction():

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,5 +1,3 @@
-from urllib.parse import quote_plus
-
 from pydantic_settings import BaseSettings
 
 
@@ -7,8 +5,6 @@ class Settings(BaseSettings):
     db_host: str = "localhost"
     db_port: int = 5432
     db_name: str = "feedforge"
-    db_user: str = "feedforge"
-    db_password: str = "feedforge"
     debug: bool = False
 
     redis_host: str = "localhost"
@@ -26,17 +22,8 @@ class Settings(BaseSettings):
     # Digest notification
     digest_lookback_hours: int = 24
     digest_provider: str = ""  # "slack" | "line" | "" (disabled)
-    digest_webhook_url: str = ""  # Slack incoming webhook URL
-    digest_line_token: str = ""  # LINE channel access token
-    digest_line_user_id: str = ""  # LINE target user/group ID
 
     model_config = {"env_prefix": "FEEDFORGE_"}
-
-    @property
-    def database_url(self) -> str:
-        user = quote_plus(self.db_user)
-        password = quote_plus(self.db_password)
-        return f"postgresql+psycopg://{user}:{password}@{self.db_host}:{self.db_port}/{self.db_name}"
 
 
 settings = Settings()

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,11 +1,27 @@
 from collections.abc import Generator
 
+import psycopg
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.config import settings
+from app.secrets import get_db_credentials
 
-engine = create_engine(settings.database_url)
+
+def _connect() -> psycopg.Connection:
+    user, password = get_db_credentials()
+    return psycopg.connect(
+        host=settings.db_host,
+        port=settings.db_port,
+        dbname=settings.db_name,
+        user=user,
+        password=password,
+    )
+
+
+# `creator=` re-runs `_connect` for every new pool connection, so credentials
+# rotated in the CSI mount are picked up without an engine restart.
+engine = create_engine("postgresql+psycopg://", creator=_connect)
 SessionLocal = sessionmaker(bind=engine)
 
 

--- a/backend/app/digest.py
+++ b/backend/app/digest.py
@@ -13,11 +13,24 @@ from sqlalchemy.orm import joinedload
 from app.config import settings
 from app.database import SessionLocal
 from app.models.article import Article
+from app.secrets import get_notification_secret
 
 logger = logging.getLogger(__name__)
 
 LINE_PUSH_URL = "https://api.line.me/v2/bot/message/push"
 LINE_TEXT_LIMIT = 5000
+
+
+def _slack_webhook_url() -> str:
+    return get_notification_secret("NOTIFICATION_WEBHOOK_URL", "FEEDFORGE_DIGEST_WEBHOOK_URL")
+
+
+def _line_token() -> str:
+    return get_notification_secret("LINE_CHANNEL_TOKEN", "FEEDFORGE_DIGEST_LINE_TOKEN")
+
+
+def _line_user_id() -> str:
+    return get_notification_secret("LINE_USER_ID", "FEEDFORGE_DIGEST_LINE_USER_ID")
 
 
 def count_recent_articles(db) -> tuple[int, int]:
@@ -74,7 +87,7 @@ def format_empty_digest() -> str:
 
 
 def _send_slack(text: str, total_articles: int) -> None:
-    resp = httpx.post(settings.digest_webhook_url, json={"text": text}, timeout=30)
+    resp = httpx.post(_slack_webhook_url(), json={"text": text}, timeout=30)
     resp.raise_for_status()
     logger.info("Slack notification sent (%d chars, %d articles)", len(text), total_articles)
 
@@ -92,9 +105,9 @@ def _send_line(text: str, total_articles: int) -> None:
 
     resp = httpx.post(
         LINE_PUSH_URL,
-        headers={"Authorization": f"Bearer {settings.digest_line_token}"},
+        headers={"Authorization": f"Bearer {_line_token()}"},
         json={
-            "to": settings.digest_line_user_id,
+            "to": _line_user_id(),
             "messages": [{"type": "text", "text": text}],
         },
         timeout=30,
@@ -117,11 +130,11 @@ def main() -> None:
         logger.error("Unknown digest_provider %r (expected: slack, line)", provider)
         sys.exit(1)
 
-    if provider == "slack" and not settings.digest_webhook_url:
-        logger.error("FEEDFORGE_DIGEST_WEBHOOK_URL is required for Slack provider")
+    if provider == "slack" and not _slack_webhook_url():
+        logger.error("Slack webhook URL is required for Slack provider (NOTIFICATION_WEBHOOK_URL file or FEEDFORGE_DIGEST_WEBHOOK_URL env)")
         sys.exit(1)
-    if provider == "line" and (not settings.digest_line_token or not settings.digest_line_user_id):
-        logger.error("FEEDFORGE_DIGEST_LINE_TOKEN and FEEDFORGE_DIGEST_LINE_USER_ID are required for LINE provider")
+    if provider == "line" and (not _line_token() or not _line_user_id()):
+        logger.error("LINE token and user ID are required for LINE provider (LINE_CHANNEL_TOKEN/LINE_USER_ID files or FEEDFORGE_DIGEST_LINE_TOKEN/FEEDFORGE_DIGEST_LINE_USER_ID env)")
         sys.exit(1)
 
     logger.info("Daily digest starting (provider=%s, lookback=%dh)", provider, settings.digest_lookback_hours)

--- a/backend/app/secrets.py
+++ b/backend/app/secrets.py
@@ -1,0 +1,42 @@
+"""Read secrets from CSI-mounted files, with env-var fallback for local dev.
+
+The CSI driver mounts secret files synchronously when the pod starts, so reads
+from `/mnt/secrets/...` are race-free (unlike env vars sourced from a synced
+K8s Secret, whose creation is async and lags the pod's first start).
+
+Helpers are called per use (not cached at import) so rotated CSI files are
+picked up on subsequent reads — at the granularity of the caller (e.g. each
+new SQLAlchemy pool connection re-reads DB credentials).
+"""
+
+import os
+from pathlib import Path
+
+POSTGRES_SECRETS_DIR = Path("/mnt/secrets/postgres")
+NOTIFICATION_SECRETS_DIR = Path("/mnt/secrets/notification")
+
+
+def read_secret(file_key: str, *, mount_dir: Path, env_var: str | None = None) -> str:
+    """Return the secret value for `file_key`.
+
+    Prefers `<mount_dir>/<file_key>` when the file exists; otherwise falls back
+    to `os.environ[env_var]` for local-dev paths where no CSI mount is present.
+    Returns "" when neither source has a value, matching the pre-existing
+    pydantic-settings empty-string default that downstream guards already check.
+    """
+    file_path = mount_dir / file_key
+    if file_path.is_file():
+        return file_path.read_text().strip()
+    if env_var:
+        return os.environ.get(env_var, "")
+    return ""
+
+
+def get_db_credentials() -> tuple[str, str]:
+    user = read_secret("POSTGRES_USER", mount_dir=POSTGRES_SECRETS_DIR, env_var="FEEDFORGE_DB_USER")
+    password = read_secret("POSTGRES_PASSWORD", mount_dir=POSTGRES_SECRETS_DIR, env_var="FEEDFORGE_DB_PASSWORD")
+    return user, password
+
+
+def get_notification_secret(file_key: str, env_var: str) -> str:
+    return read_secret(file_key, mount_dir=NOTIFICATION_SECRETS_DIR, env_var=env_var)

--- a/docs/secret-manager.md
+++ b/docs/secret-manager.md
@@ -1,9 +1,12 @@
 # Secret Management with GCP Secret Manager
 
-FeedForge secrets are stored in [GCP Secret Manager](https://cloud.google.com/secret-manager)
-and synced into pods via the
-[Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/) with the
-[GCP provider](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp).
+FeedForge production secrets are stored in
+[GCP Secret Manager](https://cloud.google.com/secret-manager) and exposed to
+pods as files under `/mnt/secrets/<group>/` via the
+[Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/) with
+the [GCP provider](https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp).
+Workloads read those files directly through `app.secrets`; no Kubernetes
+`Secret` objects are involved on the cloud path.
 
 ## Architecture
 
@@ -11,42 +14,45 @@ and synced into pods via the
 GCP Secret Manager
         │
         ▼
-  Secrets Store CSI Driver (DaemonSet on each node)
+  Secrets Store CSI Driver (DaemonSet, --enable-secret-rotation)
         │
         ▼
   SecretProviderClass (per secret group)
         │
-        ├── Mounts secrets as files in /mnt/secrets/<group>/
-        └── Syncs to K8s Secret objects (secretObjects)
-              │
-              └── Consumed by pods via env vars (secretKeyRef / envFrom)
+        └── Mounts secrets as files in /mnt/secrets/<group>/
+               │
+               └── Read by app.secrets on each access
+                   (DB: per pool connection; notifications: per send)
 ```
 
-The CSI driver syncs secrets from GCP Secret Manager into:
+There is no longer a synced K8s `Secret` for `postgres-credentials` /
+`notification-credentials` on the dev cluster. This eliminates two prior
+problems:
 
-1. **Files** mounted at `/mnt/secrets/<group>/` inside the pod
-2. **Kubernetes Secret objects** (via `secretObjects`) that pods reference through
-   existing `secretKeyRef` and `envFrom` configurations
-
-This means application code does **not** need to change — env vars are populated
-from the synced K8s Secret just as before.
+1. **Cold-start race.** The synced Secret was produced asynchronously by a
+   controller after the first pod mounted the SPC volume, so pods started
+   before it existed. CSI mount files are written synchronously on container
+   start, so the file path doesn't race.
+2. **No hot-rotation.** Env vars resolved from a Secret are frozen at pod
+   start. CSI files refresh on the rotation poll, so new pool connections
+   pick up the new value without a restart.
 
 ## Secrets Inventory
 
-### postgres-credentials
+### postgres-credentials (`/mnt/secrets/postgres/`)
 
-| GCP Secret Name | K8s Secret Key | Used By |
+| GCP Secret Name | File Name | Used By |
 |---|---|---|
 | `feedforge-postgres-user` | `POSTGRES_USER` | backend, summarizer, fetcher, digest |
 | `feedforge-postgres-password` | `POSTGRES_PASSWORD` | backend, summarizer, fetcher, digest |
 
-### notification-credentials
+### notification-credentials (`/mnt/secrets/notification/`)
 
-| GCP Secret Name | K8s Secret Key | Used By |
+| GCP Secret Name | File Name | Used By |
 |---|---|---|
-| `feedforge-notification-webhook-url` | `NOTIFICATION_WEBHOOK_URL` | digest (optional) |
-| `feedforge-line-channel-token` | `LINE_CHANNEL_TOKEN` | digest (optional) |
-| `feedforge-line-user-id` | `LINE_USER_ID` | digest (optional) |
+| `feedforge-notification-webhook-url` | `NOTIFICATION_WEBHOOK_URL` | digest (Slack provider) |
+| `feedforge-line-channel-token` | `LINE_CHANNEL_TOKEN` | digest (LINE provider) |
+| `feedforge-line-user-id` | `LINE_USER_ID` | digest (LINE provider) |
 
 ## Prerequisites
 
@@ -57,8 +63,8 @@ from the synced K8s Secret just as before.
    k8s/bootstrap/install-csi-secrets-store.sh
    ```
 
-   This installs the CSI driver (with `syncSecret.enabled=true`) and the GCP
-   provider via Helm. The script is idempotent — safe to re-run.
+   The script installs the CSI driver with `enableSecretRotation=true` and
+   `rotationPollInterval=2m`, plus the GCP provider DaemonSet. It is idempotent.
 
 2. **Workload Identity** must be enabled on the GKE cluster (already configured).
 
@@ -69,7 +75,8 @@ from the synced K8s Secret just as before.
 
 ### 1. Populate secret values in GCP Secret Manager
 
-The secret containers (e.g., `feedforge-postgres-user`) and IAM bindings are created automatically by Terraform. You only need to populate the values:
+The secret containers (e.g., `feedforge-postgres-user`) and IAM bindings are
+created automatically by Terraform. Only the values need to be populated:
 
 ```bash
 PROJECT_ID="project-76da2d1f-231c-4c94-ae9"
@@ -81,7 +88,7 @@ echo -n "feedforge" | gcloud secrets versions add feedforge-postgres-user \
 echo -n "<YOUR_PASSWORD>" | gcloud secrets versions add feedforge-postgres-password \
   --project="${PROJECT_ID}" --data-file=-
 
-# Notification credentials (optional — only needed for digest notifications)
+# Notification credentials (only needed if the digest provider is enabled)
 # echo -n "<WEBHOOK_URL>" | gcloud secrets versions add feedforge-notification-webhook-url \
 #   --project="${PROJECT_ID}" --data-file=-
 # echo -n "<TOKEN>" | gcloud secrets versions add feedforge-line-channel-token \
@@ -102,102 +109,86 @@ Terraform (`terraform/environments/dev/main.tf`) as
 | `feedforge-cloudsql-proxy` | All postgres + notification secrets |
 | `feedforge-summarizer` | Postgres secrets |
 
-These are applied automatically by `terraform apply`. No manual `gcloud`
-commands needed.
-
 ### 3. SecretProviderClass PROJECT_ID
 
-The base `SecretProviderClass` manifests in `k8s/base/secret-store/` contain a
-literal `PROJECT_ID` placeholder. Each overlay (e.g., `k8s/overlays/dev/`)
-patches these with the real GCP project ID via kustomize strategic merge patches:
+The base `SecretProviderClass` manifests have a literal `PROJECT_ID`
+placeholder. Each overlay patches it with the real project ID via
+strategic-merge patches:
 
-- `patches/spc-postgres-patch.yaml`
-- `patches/spc-notification-patch.yaml`
+- `k8s/overlays/dev/patches/spc-postgres-patch.yaml`
+- `k8s/overlays/dev/patches/spc-notification-patch.yaml`
 
-When adding a new environment, copy these patch files into the new overlay and
-update the project ID. **Do not edit the base manifests directly.**
+When adding a new environment, copy these patch files and update the project
+ID. **Do not edit the base manifests directly.**
 
 ### 4. Deploy
 
 ```bash
-# Apply the updated manifests
-skaffold run
+skaffold run -p dev
 
-# Verify secrets are synced
-kubectl get secrets -n feedforge
-kubectl describe secretproviderclasspodstatus -n feedforge
+# The synced K8s Secrets are intentionally absent. Verify the SPCs are healthy
+# and the CSI mount is present in the pods:
+kubectl -n feedforge get secretproviderclass
+kubectl -n feedforge exec deploy/backend -- ls /mnt/secrets/postgres
 ```
 
 ## Rotating Secrets
 
-To rotate a secret, add a new version in Secret Manager:
+Add a new version in Secret Manager:
 
 ```bash
 echo -n "<NEW_VALUE>" | gcloud secrets versions add feedforge-postgres-password \
   --project="${PROJECT_ID}" --data-file=-
 ```
 
-How the new value propagates depends on how pods consume the secret:
+Within `rotationPollInterval` (2 minutes) the CSI driver re-reads Secret
+Manager and rewrites the file at `/mnt/secrets/<group>/<file>`. Propagation
+into the running app:
 
-- **Mounted files** (`/mnt/secrets/<group>/`): The CSI driver's
-  `--rotation-poll-interval` (default: 2 minutes) automatically refreshes
-  mounted files when a new secret version is published. No pod restart needed.
-- **Environment variables** (`secretKeyRef` / `envFrom`): Env vars are resolved
-  at pod start time and are **not** auto-refreshed. A rolling restart is
-  required to pick up new values:
+- **DB credentials.** SQLAlchemy's pool calls `_connect` (in
+  `backend/app/database.py`) on each new connection, which re-reads the
+  current values from `/mnt/secrets/postgres/`. New pool connections use the
+  new password; existing pooled connections keep working with the old value
+  until they recycle (idle timeout / `pool_recycle`). No pod restart needed.
+- **Notification credentials.** Read on every send call inside
+  `_send_slack` / `_send_line`, so the next digest run picks up the new
+  value automatically.
 
-  ```bash
-  kubectl rollout restart deployment/backend -n feedforge
-  ```
-
-**Recommended practice:** If your application can read secrets from the mounted
-files at `/mnt/secrets/<group>/` instead of env vars, rotation is fully
-automatic. If using env vars (the current default), perform a rolling restart
-after publishing a new secret version.
-
-## Migration from Kubernetes Secrets
-
-Previously, secrets were stored as plain Kubernetes Secrets created manually via
-`kubectl create secret`. The old approach had these limitations:
-
-- Base64-encoded, not encrypted at rest by default
-- No audit logging for secret access
-- No built-in rotation mechanism
-- Secrets visible to anyone with `kubectl get secret` access
-
-Once Secret Manager is confirmed working, any manually-created K8s Secrets
-should be removed:
+To force immediate adoption (e.g. emergency rotation), restart the deployments
+or wait for the cron'd workloads to fire:
 
 ```bash
-# Only run after confirming Secret Manager secrets are working
-kubectl delete secret postgres-credentials -n feedforge
-kubectl delete secret notification-credentials -n feedforge
+kubectl -n feedforge rollout restart deployment/backend deployment/summarizer
 ```
 
-## First Deploy
+## Local Development
 
-On a cold-start (first `skaffold run` on a fresh cluster), there is a brief race
-condition:
+Local-dev paths do not have the Secret-Store CSI driver installed, so
+`/mnt/secrets/...` does not exist. `app.secrets.read_secret` falls back to
+environment variables:
 
-1. The CSI driver creates the K8s Secret (`postgres-credentials`,
-   `notification-credentials`) only **after** the first pod mounts the
-   `SecretProviderClass` volume.
-2. Other pods that reference these secrets via `secretKeyRef` may briefly
-   CrashLoopBackOff until the Secret objects exist.
+| File key | Env-var fallback |
+|---|---|
+| `POSTGRES_USER` | `FEEDFORGE_DB_USER` |
+| `POSTGRES_PASSWORD` | `FEEDFORGE_DB_PASSWORD` |
+| `NOTIFICATION_WEBHOOK_URL` | `FEEDFORGE_DIGEST_WEBHOOK_URL` |
+| `LINE_CHANNEL_TOKEN` | `FEEDFORGE_DIGEST_LINE_TOKEN` |
+| `LINE_USER_ID` | `FEEDFORGE_DIGEST_LINE_USER_ID` |
 
-All `secretKeyRef` entries are marked `optional: true` to prevent immediate pod
-failures. However, pods still need the env vars to function — their readiness
-probes will fail until the secrets are available, keeping them out of the Service
-endpoints until they are healthy.
-
-This is a one-time bootstrap issue. After the first successful pod mount, the
-K8s Secret persists and subsequent pod starts find it immediately.
+- **Docker-compose / pure Python** (`.env.local`): `pydantic-settings` loads
+  the `FEEDFORGE_*` vars; the helper hits the env-var branch.
+- **Local kind cluster** (`k8s/overlays/local`): the postgres-cnpg
+  component (`k8s/components/postgres-cnpg/{backend,fetcher,summarizer,digest}-env-patch.yaml`)
+  injects `FEEDFORGE_DB_USER` / `FEEDFORGE_DB_PASSWORD` from the in-cluster
+  `postgres-credentials` Secret via `secretKeyRef`. The local overlay's
+  `patches/digest-patch.yaml` does the same for the notification secret
+  (sourced from the developer-provided `secret-notification.yaml`).
 
 ## Troubleshooting
 
 ### Pods stuck in ContainerCreating
 
-The CSI driver must be installed and the GCP provider must be running. Check:
+The CSI driver and the GCP provider must be running:
 
 ```bash
 kubectl get pods -n kube-system -l app=secrets-store-csi-driver
@@ -206,22 +197,20 @@ kubectl get pods -n kube-system -l app=csi-secrets-store-provider-gcp
 
 ### Permission denied accessing secrets
 
-Verify Workload Identity binding and IAM roles:
+Verify Workload Identity binding and IAM:
 
 ```bash
-# Check the KSA → GSA binding
 kubectl get serviceaccount <name> -n feedforge -o yaml | grep gcp-service-account
-
-# Check the GSA has secretAccessor role
 gcloud secrets get-iam-policy feedforge-postgres-user --project="${PROJECT_ID}"
 ```
 
-### Secrets not updating after rotation
+### App still uses old credentials after rotation
 
-Mounted files auto-refresh via the CSI driver's rotation poll interval. If the
-application reads secrets from **env vars**, those are set at pod start and
-require a restart:
+Mounted files refresh on the rotation poll (≤ 2 minutes). If the file content
+is current but the app is still using the old value, the SQLAlchemy pool is
+holding old connections — wait for `pool_recycle`, force traffic to drain
+the pool, or `kubectl rollout restart` the workload.
 
 ```bash
-kubectl rollout restart deployment/<name> -n feedforge
+kubectl -n feedforge exec deploy/backend -- cat /mnt/secrets/postgres/POSTGRES_USER
 ```

--- a/k8s/base/backend/deployment.yaml
+++ b/k8s/base/backend/deployment.yaml
@@ -42,19 +42,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: backend-config
-          env:
-            - name: FEEDFORGE_DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-credentials
-                  key: POSTGRES_USER
-                  optional: true
-            - name: FEEDFORGE_DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-credentials
-                  key: POSTGRES_PASSWORD
-                  optional: true
           resources:
             requests:
               cpu: 50m
@@ -100,19 +87,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: backend-config
-          env:
-            - name: FEEDFORGE_DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-credentials
-                  key: POSTGRES_USER
-                  optional: true
-            - name: FEEDFORGE_DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-credentials
-                  key: POSTGRES_PASSWORD
-                  optional: true
           resources:
             requests:
               cpu: 100m

--- a/k8s/base/digest/cronjob.yaml
+++ b/k8s/base/digest/cronjob.yaml
@@ -43,38 +43,8 @@ spec:
                 - configMapRef:
                     name: backend-config
               env:
-                - name: FEEDFORGE_DB_USER
-                  valueFrom:
-                    secretKeyRef:
-                      name: postgres-credentials
-                      key: POSTGRES_USER
-                      optional: true
-                - name: FEEDFORGE_DB_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: postgres-credentials
-                      key: POSTGRES_PASSWORD
-                      optional: true
                 - name: FEEDFORGE_DIGEST_PROVIDER
                   value: "line"
-                - name: FEEDFORGE_DIGEST_WEBHOOK_URL
-                  valueFrom:
-                    secretKeyRef:
-                      name: notification-credentials
-                      key: NOTIFICATION_WEBHOOK_URL
-                      optional: true
-                - name: FEEDFORGE_DIGEST_LINE_TOKEN
-                  valueFrom:
-                    secretKeyRef:
-                      name: notification-credentials
-                      key: LINE_CHANNEL_TOKEN
-                      optional: true
-                - name: FEEDFORGE_DIGEST_LINE_USER_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: notification-credentials
-                      key: LINE_USER_ID
-                      optional: true
               volumeMounts:
                 - name: notification-creds
                   mountPath: /mnt/secrets/notification

--- a/k8s/base/fetcher/cronjob.yaml
+++ b/k8s/base/fetcher/cronjob.yaml
@@ -42,19 +42,6 @@ spec:
               envFrom:
                 - configMapRef:
                     name: backend-config
-              env:
-                - name: FEEDFORGE_DB_USER
-                  valueFrom:
-                    secretKeyRef:
-                      name: postgres-credentials
-                      key: POSTGRES_USER
-                      optional: true
-                - name: FEEDFORGE_DB_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: postgres-credentials
-                      key: POSTGRES_PASSWORD
-                      optional: true
               resources:
                 requests:
                   cpu: 50m

--- a/k8s/base/secret-store/secretproviderclass-notification.yaml
+++ b/k8s/base/secret-store/secretproviderclass-notification.yaml
@@ -22,13 +22,3 @@ spec:
         path: "LINE_CHANNEL_TOKEN"
       - resourceName: "projects/PROJECT_ID/secrets/feedforge-line-user-id/versions/latest"
         path: "LINE_USER_ID"
-  secretObjects:
-    - secretName: notification-credentials
-      type: Opaque
-      data:
-        - objectName: "NOTIFICATION_WEBHOOK_URL"
-          key: NOTIFICATION_WEBHOOK_URL
-        - objectName: "LINE_CHANNEL_TOKEN"
-          key: LINE_CHANNEL_TOKEN
-        - objectName: "LINE_USER_ID"
-          key: LINE_USER_ID

--- a/k8s/base/summarizer/deployment.yaml
+++ b/k8s/base/summarizer/deployment.yaml
@@ -43,19 +43,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: backend-config
-          env:
-            - name: FEEDFORGE_DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-credentials
-                  key: POSTGRES_USER
-                  optional: true
-            - name: FEEDFORGE_DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-credentials
-                  key: POSTGRES_PASSWORD
-                  optional: true
           resources:
             requests:
               cpu: 50m

--- a/k8s/bootstrap/install-csi-secrets-store.sh
+++ b/k8s/bootstrap/install-csi-secrets-store.sh
@@ -10,8 +10,11 @@ set -euo pipefail
 
 # --- Secrets Store CSI Driver (Helm) ---
 # Deploys the DaemonSet that mounts external secrets as volumes in pods.
-# syncSecret.enabled=true allows the driver to sync mounted secrets into
-# native Kubernetes Secret objects (used by secretObjects in SecretProviderClass).
+# enableSecretRotation=true makes the driver re-poll Secret Manager every
+# rotationPollInterval (2m) so rotated values land on disk without a pod
+# restart. syncSecret.enabled is left off — workloads read CSI mount files
+# directly via app.secrets, so the synced K8s Secret objects are no longer
+# needed (and removing them keeps secrets out of `kubectl get secret`).
 
 helm repo add secrets-store-csi-driver \
   https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
@@ -20,7 +23,8 @@ helm repo update secrets-store-csi-driver
 helm upgrade --install csi-secrets-store \
   secrets-store-csi-driver/secrets-store-csi-driver \
   --namespace kube-system \
-  --set syncSecret.enabled=true \
+  --set enableSecretRotation=true \
+  --set rotationPollInterval=2m \
   --wait
 
 echo "Secrets Store CSI Driver installed."

--- a/k8s/components/postgres-cloudsql/backend-init-patch.yaml
+++ b/k8s/components/postgres-cloudsql/backend-init-patch.yaml
@@ -1,0 +1,18 @@
+# Mount the postgres-creds CSI volume on the run-migrations init container.
+# The volume + main-container mount are added by backend-patch.yaml (JSON 6902);
+# this strategic-merge patch adds the init-container mount by name so alembic
+# can read /mnt/secrets/postgres/POSTGRES_{USER,PASSWORD} via app.secrets.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: feedforge
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: run-migrations
+          volumeMounts:
+            - name: postgres-creds
+              mountPath: /mnt/secrets/postgres
+              readOnly: true

--- a/k8s/components/postgres-cloudsql/kustomization.yaml
+++ b/k8s/components/postgres-cloudsql/kustomization.yaml
@@ -18,6 +18,7 @@ patches:
       version: v1
       kind: Deployment
       name: backend
+  - path: backend-init-patch.yaml
   - path: backend-sa-patch.yaml
   - path: fetcher-patch.yaml
   - path: fetcher-sa-patch.yaml

--- a/k8s/components/postgres-cloudsql/secretproviderclass.yaml
+++ b/k8s/components/postgres-cloudsql/secretproviderclass.yaml
@@ -21,11 +21,3 @@ spec:
         path: "POSTGRES_USER"
       - resourceName: "projects/PROJECT_ID/secrets/feedforge-postgres-password/versions/latest"
         path: "POSTGRES_PASSWORD"
-  secretObjects:
-    - secretName: postgres-credentials
-      type: Opaque
-      data:
-        - objectName: "POSTGRES_USER"
-          key: POSTGRES_USER
-        - objectName: "POSTGRES_PASSWORD"
-          key: POSTGRES_PASSWORD

--- a/k8s/components/postgres-cnpg/backend-env-patch.yaml
+++ b/k8s/components/postgres-cnpg/backend-env-patch.yaml
@@ -1,0 +1,39 @@
+# Wire FEEDFORGE_DB_USER/PASSWORD env vars from the postgres-credentials Secret
+# (created by credentials.yaml) into both the run-migrations init container
+# (alembic) and the main backend container. The Secret is present at pod start,
+# so no `optional: true` is needed. The base manifests no longer carry these
+# refs because the cloud-sql overlay reads creds from the CSI mount instead.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: feedforge
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: run-migrations
+          env:
+            - name: FEEDFORGE_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: POSTGRES_USER
+            - name: FEEDFORGE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: POSTGRES_PASSWORD
+      containers:
+        - name: backend
+          env:
+            - name: FEEDFORGE_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: POSTGRES_USER
+            - name: FEEDFORGE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: POSTGRES_PASSWORD

--- a/k8s/components/postgres-cnpg/digest-env-patch.yaml
+++ b/k8s/components/postgres-cnpg/digest-env-patch.yaml
@@ -1,0 +1,26 @@
+# Wire FEEDFORGE_DB_USER/PASSWORD env vars from the postgres-credentials Secret
+# into the daily-digest CronJob. Notification credentials are local-overlay
+# concern (handled in overlays/local/patches/digest-patch.yaml).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: daily-digest
+  namespace: feedforge
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: digest
+              env:
+                - name: FEEDFORGE_DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-credentials
+                      key: POSTGRES_USER
+                - name: FEEDFORGE_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-credentials
+                      key: POSTGRES_PASSWORD

--- a/k8s/components/postgres-cnpg/fetcher-env-patch.yaml
+++ b/k8s/components/postgres-cnpg/fetcher-env-patch.yaml
@@ -1,0 +1,26 @@
+# Wire FEEDFORGE_DB_USER/PASSWORD env vars from the postgres-credentials Secret
+# into the fetcher CronJob. app.secrets falls back to env vars when no CSI
+# mount is present (kind has no Secret-Store CSI driver).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: feed-fetcher
+  namespace: feedforge
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: fetcher
+              env:
+                - name: FEEDFORGE_DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-credentials
+                      key: POSTGRES_USER
+                - name: FEEDFORGE_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-credentials
+                      key: POSTGRES_PASSWORD

--- a/k8s/components/postgres-cnpg/kustomization.yaml
+++ b/k8s/components/postgres-cnpg/kustomization.yaml
@@ -13,3 +13,10 @@ resources:
 patches:
   - path: backend-patch.yaml
   - path: backend-config-patch.yaml
+  # Env-var fallback for app.secrets — Secret-Store CSI driver isn't installed
+  # in kind, so the four workloads source DB creds from the in-cluster
+  # postgres-credentials Secret via secretKeyRef.
+  - path: backend-env-patch.yaml
+  - path: fetcher-env-patch.yaml
+  - path: summarizer-env-patch.yaml
+  - path: digest-env-patch.yaml

--- a/k8s/components/postgres-cnpg/summarizer-env-patch.yaml
+++ b/k8s/components/postgres-cnpg/summarizer-env-patch.yaml
@@ -1,0 +1,24 @@
+# Wire FEEDFORGE_DB_USER/PASSWORD env vars from the postgres-credentials Secret
+# into the summarizer Deployment. app.secrets falls back to env vars when no
+# CSI mount is present (kind has no Secret-Store CSI driver).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: summarizer
+  namespace: feedforge
+spec:
+  template:
+    spec:
+      containers:
+        - name: summarizer
+          env:
+            - name: FEEDFORGE_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: POSTGRES_USER
+            - name: FEEDFORGE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: POSTGRES_PASSWORD

--- a/k8s/overlays/local/patches/digest-patch.yaml
+++ b/k8s/overlays/local/patches/digest-patch.yaml
@@ -1,9 +1,8 @@
 # Strip the notification-credentials Secret-Store CSI volume from the
-# daily-digest CronJob. The CSI driver isn't installed in kind, so the
-# volume mount would fail. The container's secretKeyRef env vars
-# (NOTIFICATION_WEBHOOK_URL, LINE_*) are marked optional: true and resolve
-# to empty when the Secret doesn't exist — digest will run but won't
-# actually send notifications, which is fine for local development.
+# daily-digest CronJob (kind has no CSI driver) and wire the same secret
+# values via env-var refs sourced from the developer-provided
+# `notification-credentials` Secret (see secret-notification.yaml.example).
+# app.secrets falls back to env vars when no CSI mount is present.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -16,6 +15,22 @@ spec:
         spec:
           containers:
             - name: digest
+              env:
+                - name: FEEDFORGE_DIGEST_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: notification-credentials
+                      key: NOTIFICATION_WEBHOOK_URL
+                - name: FEEDFORGE_DIGEST_LINE_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: notification-credentials
+                      key: LINE_CHANNEL_TOKEN
+                - name: FEEDFORGE_DIGEST_LINE_USER_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: notification-credentials
+                      key: LINE_USER_ID
               volumeMounts:
                 - name: notification-creds
                   $patch: delete


### PR DESCRIPTION
## Summary

- Workloads now read postgres + notification credentials directly from the CSI mount (`/mnt/secrets/...`) via a new `app.secrets` helper, replacing the env-vars-from-synced-K8s-Secret pattern.
- `secretObjects:` removed from both SecretProviderClasses — the synced `postgres-credentials` / `notification-credentials` K8s Secrets are gone, eliminating the cold-start race and the `kubectl get secret` exposure surface.
- `--enable-secret-rotation` (poll = 2m) turned on in the CSI driver bootstrap. `creator=` callable on the SQLAlchemy engine re-reads creds per new pool connection so rotated values land without a pod restart.
- Local-dev paths preserved via the helper's env-var fallback: docker-compose/Python uses `.env.local`; the kind overlay (postgres-cnpg + dev-supplied notification Secret) wires `FEEDFORGE_DB_USER/PASSWORD` and `FEEDFORGE_DIGEST_*` via `secretKeyRef` so the CSI driver isn't required in kind.

Closes #30

## Test plan

**Read-only (already done locally):**
- [x] `python3 -m py_compile` passes on all 5 modified Python files.
- [x] `kubectl kustomize k8s/overlays/dev` renders cleanly: no `secretObjects:`, no `secretKeyRef` env vars, `/mnt/secrets/postgres` mounted on backend init+main + fetcher + summarizer + digest, `/mnt/secrets/notification` mounted on digest.
- [x] `kubectl kustomize k8s/overlays/local` renders cleanly: env-var fallback wired on all 4 workloads from the in-cluster Secret + dev-supplied notification Secret.
- [x] Helm chart values confirmed against `helm show values secrets-store-csi-driver/secrets-store-csi-driver`.

**Mutations (run manually):**
- [ ] `k8s/bootstrap/install-csi-secrets-store.sh` — re-bootstrap CSI driver with rotation enabled.
- [ ] `skaffold run -p dev` — fresh deploy.
- [ ] `kubectl -n feedforge get events --sort-by=.lastTimestamp | tail -50` — no `CrashLoopBackOff` on backend, no `Job failed` for digest tied to missing creds.
- [ ] `kubectl -n feedforge get secret postgres-credentials notification-credentials` — both `NotFound` after rollout (the synced secrets are no longer produced).
- [ ] `kubectl -n feedforge exec deploy/backend -- ls /mnt/secrets/postgres` — `POSTGRES_USER POSTGRES_PASSWORD` files present.
- [ ] `kubectl -n feedforge create job --from=cronjob/daily-digest digest-test-1` — successful send, logs show LINE/Slack delivery.
- [ ] Hot-rotation smoke: `gcloud secrets versions add feedforge-line-user-id --data-file=-` then wait ≤ 2 min; verify the file under `/mnt/secrets/notification/LINE_USER_ID` reflects the new value.
- [ ] Cleanup: `kubectl -n feedforge delete secret postgres-credentials notification-credentials` if either still lingers from before deploy.

## Side findings (out of scope, flagging only)

- `k8s/base/digest/secret-notification.yaml{,.example}` — orphan files, not referenced in `k8s/base/digest/kustomization.yaml`. Likely leftover from #41's local-side migration. Worth a follow-up cleanup.
- `k8s/base/postgres/secret-postgres.yaml` — committed file with a hardcoded password. The `.gitignore` rule `k8s/**/secret-*.yaml` should have excluded it. Worth auditing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)