### PR TITLE
chore: harden init containers + audit postgres-cloudsql patches

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -8,7 +8,9 @@ You are the feedforge code reviewer — a read-only specialist that catches mist
 
 ## What you review
 
-By default: staged changes (`git diff --cached`). If the caller specifies files, a commit range, or "the last commit", scope to that instead.
+By default: all working-tree changes vs `HEAD` — both staged and unstaged (`git diff HEAD`). This covers the common case where the main session just finished editing files but hasn't staged or committed them yet.
+
+If the caller specifies a different scope (files, commit range, or "the last commit"), use that instead.
 
 ## What you load before reviewing
 
@@ -23,7 +25,7 @@ Do not skip this step. Quoting the exact rule in each finding is what makes you 
 
 ## Method
 
-1. Identify the change set (`git diff --cached` by default)
+1. Identify the change set (`git diff HEAD` by default — staged plus unstaged)
 2. For each touched file:
    - Match changes against rules — quote the exact rule clause violated
    - Check blast radius: does this affect other modules, overlays, or downstream resources?
@@ -66,6 +68,6 @@ Omit any severity bucket with no findings. If nothing fires, write "no findings"
 - Don't propose new architecture or refactors outside the change set — out of scope
 - Don't hedge or be polite — terse and specific beats verbose
 - Don't approve a change that violates a documented rule even if it "works"
-- Don't review code outside the staged set unless explicitly asked
+- Don't review code outside the change set (staged + unstaged vs HEAD) unless explicitly asked
 - Don't write or edit any file — you have no Edit/Write tools, by design
 - Don't recurse into other subagents — finish your review and report

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,19 @@ This project follows a structured SDLC. See [CONTRIBUTING.md](CONTRIBUTING.md) f
 - Before ending session: remind user to `terraform destroy` if cluster is up.
 - If budget is tight: scale to 1 node or switch to e2-small.
 
+## Automatic infra review
+
+After any turn that modifies one or more `*.tf` files, or YAML files under `k8s/`, **before sending the final reply**:
+
+1. Invoke the `feedforge-reviewer` subagent via the Task tool. It defaults to `git diff HEAD` (covers your unstaged edits) — no need to pass scope unless reviewing something else (a specific commit, a different branch).
+2. If the reviewer returns **BLOCKERS**: address each one in this turn before completing. Re-invoke the reviewer after fixes only if the fixes were non-trivial.
+3. If **WARNINGS** or **NOTES**: summarize them in your reply so the user can see them at a glance. Don't auto-fix warnings — they may be intentional tradeoffs the user owns.
+4. **Skip the review** only for these cases (and note the skip in your reply when you do):
+   - Comment-only / whitespace-only edits
+   - Reverting an edit you just made in the same turn
+   - The user explicitly says "skip review" for this turn
+5. Don't recursively invoke the reviewer from inside another subagent — main-session invocations only.
+
 ## Plan Mode for non-trivial changes
 
 Drop into Plan Mode (Shift+Tab) and save the plan to `.plans/YYYYMMDD-<slug>.md` before executing for:

--- a/k8s/base/backend/deployment.yaml
+++ b/k8s/base/backend/deployment.yaml
@@ -33,12 +33,15 @@ spec:
       initContainers:
         - name: run-migrations
           image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:cloud-sql
+          imagePullPolicy: IfNotPresent
           command: ["alembic", "upgrade", "head"]
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           envFrom:
             - configMapRef:
                 name: backend-config
@@ -51,6 +54,7 @@ spec:
               memory: 128Mi
         - name: log-exporter
           image: busybox:1.37
+          imagePullPolicy: IfNotPresent
           restartPolicy: Always
           command: ["sh", "-c"]
           args:
@@ -60,6 +64,8 @@ spec:
             readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             requests:
               cpu: 10m

--- a/k8s/components/postgres-cloudsql/backend-patch.yaml
+++ b/k8s/components/postgres-cloudsql/backend-patch.yaml
@@ -15,6 +15,7 @@
   value:
     - name: cloud-sql-proxy
       image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.15.2
+      imagePullPolicy: IfNotPresent
       restartPolicy: Always
       args:
         - "--structured-logs"
@@ -29,6 +30,8 @@
         readOnlyRootFilesystem: true
         capabilities:
           drop: ["ALL"]
+        seccompProfile:
+          type: RuntimeDefault
       resources:
         requests:
           cpu: 10m
@@ -38,12 +41,15 @@
           memory: 64Mi
     - name: run-migrations
       image: us-central1-docker.pkg.dev/project-76da2d1f-231c-4c94-ae9/feedforge/backend:cloud-sql
+      imagePullPolicy: IfNotPresent
       command: ["alembic", "upgrade", "head"]
       securityContext:
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true
         capabilities:
           drop: ["ALL"]
+        seccompProfile:
+          type: RuntimeDefault
       envFrom:
         - configMapRef:
             name: backend-config
@@ -60,6 +66,7 @@
           readOnly: true
     - name: log-exporter
       image: busybox:1.37
+      imagePullPolicy: IfNotPresent
       restartPolicy: Always
       command: ["sh", "-c"]
       args:
@@ -69,6 +76,8 @@
         readOnlyRootFilesystem: true
         capabilities:
           drop: ["ALL"]
+        seccompProfile:
+          type: RuntimeDefault
       resources:
         requests:
           cpu: 10m

--- a/k8s/components/postgres-cloudsql/digest-patch.yaml
+++ b/k8s/components/postgres-cloudsql/digest-patch.yaml
@@ -2,6 +2,10 @@
 # restartPolicy: Always) and the postgres-creds Secret-Store CSI volume.
 # Notification creds (LINE webhook etc.) are owned by the digest's own base
 # files — not Cloud SQL related — and stay there.
+#
+# Safe vs the kustomize 5.5 ordered-array reorder bug (#43, #45): the base
+# CronJob declares no initContainers, so this patch supplies the whole array
+# rather than a subset — there are no unmatched base items to be reordered.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -15,6 +19,7 @@ spec:
           initContainers:
             - name: cloud-sql-proxy
               image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.15.2
+              imagePullPolicy: IfNotPresent
               restartPolicy: Always
               args:
                 - "--structured-logs"
@@ -29,6 +34,8 @@ spec:
                 readOnlyRootFilesystem: true
                 capabilities:
                   drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
               resources:
                 requests:
                   cpu: 10m

--- a/k8s/components/postgres-cloudsql/fetcher-patch.yaml
+++ b/k8s/components/postgres-cloudsql/fetcher-patch.yaml
@@ -15,6 +15,7 @@ spec:
           initContainers:
             - name: cloud-sql-proxy
               image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.15.2
+              imagePullPolicy: IfNotPresent
               restartPolicy: Always
               args:
                 - "--structured-logs"
@@ -29,6 +30,8 @@ spec:
                 readOnlyRootFilesystem: true
                 capabilities:
                   drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
               resources:
                 requests:
                   cpu: 10m

--- a/k8s/components/postgres-cloudsql/summarizer-patch.yaml
+++ b/k8s/components/postgres-cloudsql/summarizer-patch.yaml
@@ -2,6 +2,11 @@
 # Secret-Store CSI volume. Sidecar pattern keeps the proxy alive for the
 # summarizer's worker loop. Strategic merge appends cloud-sql-proxy after
 # the summarizer container, matching the original base-file ordering.
+#
+# Safe vs the kustomize 5.5 ordered-array reorder bug (#43, #45): the patch's
+# containers list is a superset of the base (it names every base container),
+# so there are no unmatched base items left to reorder. Container order in a
+# Deployment is also non-functional, unlike initContainers.
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
## Summary
- Adds `imagePullPolicy: IfNotPresent` and `securityContext.seccompProfile.type: RuntimeDefault` to every init container in the rendered dev manifests — backend Deployment (`run-migrations`, `log-exporter`, `cloud-sql-proxy`) and the fetcher/digest CronJobs (`cloud-sql-proxy`). Satisfies the PodSpec-defaults rule in `.claude/rules/k8s-yaml.md`.
- Documents the kustomize 5.5 ordered-array reorder safety analysis on the `digest-patch.yaml` and `summarizer-patch.yaml` patches in `k8s/components/postgres-cloudsql/`. Audit conclusion for #45: no other patches in that component trigger the bug — they either patch unordered fields or supply a fresh array (not a subset of an existing base array), so no functional changes were required.

## Test plan
- [x] `kubectl kustomize k8s/base` renders cleanly
- [x] `kubectl kustomize k8s/overlays/dev` renders cleanly
- [x] `kubeconform -strict -ignore-missing-schemas` on both renders: 90 resources, 0 invalid, 0 errors
- [x] `skaffold run` deploys to dev cluster without error
- [x] Post-deploy spot check: `kubectl get deployment backend -n feedforge -o jsonpath='{.spec.template.spec.initContainers[*].imagePullPolicy}'` returns `IfNotPresent IfNotPresent IfNotPresent`
- [ ] After next fetcher / digest CronJob run, spot-check that the `cloud-sql-proxy` init container also reports `imagePullPolicy=IfNotPresent` and `seccompProfile.type=RuntimeDefault`

Closes #45
Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)